### PR TITLE
fix(stp): stop "Maximum update depth exceeded" loop in date-range init effect

### DIFF
--- a/muscatbay/app/app/stp/page.tsx
+++ b/muscatbay/app/app/stp/page.tsx
@@ -263,22 +263,36 @@ export default function STPPage() {
         });
     }, [allMonths, selectedYear]);
 
-    // Initialize start and end months when data loads, and validate saved prefs against actual data
-    useEffect(() => {
-        if (allMonths.length > 0) {
-            const startValid = startMonth && allMonths.includes(startMonth);
-            const endValid = endMonth && allMonths.includes(endMonth);
-            const latestMonth = allMonths[allMonths.length - 1];
+    // Read the current range through refs so the validation effect below does NOT
+    // depend on startMonth/endMonth. An effect that depends on the very state it
+    // sets re-fires on its own updates — the classic "Maximum update depth
+    // exceeded" loop. The legitimate triggers are data-driven (allMonths) and
+    // filter-driven (selectedYear), never the range values themselves.
+    const startMonthRef = useRef(startMonth);
+    startMonthRef.current = startMonth;
+    const endMonthRef = useRef(endMonth);
+    endMonthRef.current = endMonth;
 
-            if (!startValid || !endValid) {
-                setStartMonth(allMonths[0]);
-                setEndMonth(latestMonth);
-            } else if (!selectedYear && endMonth !== latestMonth) {
-                // No year filter active — auto-extend to newest data when new months arrive
-                setEndMonth(latestMonth);
-            }
+    // Initialize start/end months when data loads, validate saved prefs against
+    // the actual data, and auto-extend to the newest month when new data arrives.
+    useEffect(() => {
+        if (allMonths.length === 0) return;
+
+        const start = startMonthRef.current;
+        const end = endMonthRef.current;
+        const startValid = start && allMonths.includes(start);
+        const endValid = end && allMonths.includes(end);
+        const latestMonth = allMonths[allMonths.length - 1];
+
+        if (!startValid || !endValid) {
+            // Missing or stale selection — snap to the full available range.
+            if (start !== allMonths[0]) setStartMonth(allMonths[0]);
+            if (end !== latestMonth) setEndMonth(latestMonth);
+        } else if (!selectedYear && end !== latestMonth) {
+            // No year filter active — extend to newest data when new months arrive.
+            setEndMonth(latestMonth);
         }
-    }, [allMonths, startMonth, endMonth, selectedYear]);
+    }, [allMonths, selectedYear]);
 
     // Calculate filtered operations based on start/end month selection
     const operations = useMemo(() => {


### PR DESCRIPTION
## Problem

The STP page threw a console error in dev:

> **Maximum update depth exceeded.** This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
>
> at `STPPage.useEffect (app/stp/page.tsx)`

## Root cause

The effect that initializes/validates the start & end month was **self-referential** — it listed `startMonth` and `endMonth` in its dependency array *and* called `setStartMonth`/`setEndMonth` inside:

```ts
useEffect(() => {
  if (allMonths.length > 0) {
    const startValid = startMonth && allMonths.includes(startMonth);
    const endValid = endMonth && allMonths.includes(endMonth);
    const latestMonth = allMonths[allMonths.length - 1];
    if (!startValid || !endValid) {
      setStartMonth(allMonths[0]);
      setEndMonth(latestMonth);
    } else if (!selectedYear && endMonth !== latestMonth) {
      setEndMonth(latestMonth);
    }
  }
}, [allMonths, startMonth, endMonth, selectedYear]); // ← reads + writes the same state
```

Because the effect re-runs on the very state it writes, it can re-enter itself and trip React's update-depth guard. (Adding `if (a !== b)` value guards alone doesn't break the cycle — the effect still re-fires on its own updates.)

## Fix

Read the current range through **refs**, so the effect depends only on its real triggers — `allMonths` (data) and `selectedYear` (filter) — never on the range values it sets. Also only write when the value actually changes.

This makes the loop impossible by construction and additionally fixes a latent UX bug: with no year filter, picking an earlier end month previously snapped right back to the latest month, because the auto-extend branch fired on the user's own selection. Now auto-extend only happens when new data (`allMonths`) actually arrives.

## Verification

- `npx eslint app/stp/page.tsx` → clean (no `react-hooks/exhaustive-deps` warning)
- `npx tsc --noEmit` → passes

## Notes

The error trace referenced `app/stp/page.tsx:476` with `nextStartMonth` guards — that variant isn't present on `main` or this branch (the effect lives at ~line 266 here), so the running copy was a local/uncommitted attempt at the same fix. This change replaces that fragile pattern with a loop-proof one at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CF8gQG9JFi8ASJCN5DGSQv)_