### PR TITLE
Fix audit findings: a11y, theming, touch targets, performance, polish

### DIFF
--- a/muscatbay/app/app/globals.css
+++ b/muscatbay/app/app/globals.css
@@ -438,6 +438,20 @@
   --chart-cursor-fill: rgba(255, 255, 255, 0.06);
   --chart-grid: rgba(148, 163, 184, 0.18);
 
+  /* Chart Background Colors — dark mode.
+   * Light-mode values (--chart-bg-*) are pale pastels that wash out and clash
+   * against the warm near-black surfaces (--card #16141B, --background #0A090C).
+   * Override with deep, low-chroma tints (~12–17% lightness) that sit just above
+   * the card surface and keep the hue association so KPI tiles read correctly. */
+  --chart-bg-blue: #131A26;
+  --chart-bg-green: #121E18;
+  --chart-bg-yellow: #201D11;
+  --chart-bg-red: #231314;
+  --chart-bg-purple: #1B1422;
+  --chart-bg-cyan: #11201F;
+  --chart-bg-orange: #221A11;
+  --chart-bg-pink: #221320;
+
   /* Badge fg colors flip to the badge color itself for readability on dark surfaces */
   --badge-green-fg:  #A4DCC6;
   --badge-red-fg:    #E05050;

--- a/muscatbay/app/app/hvac/page.tsx
+++ b/muscatbay/app/app/hvac/page.tsx
@@ -104,9 +104,9 @@ export default function GulfExpertPage() {
         />
         <div role="alert" className="bg-card rounded-xl border border-[var(--status-danger)]/30 p-8 text-center">
           <AlertTriangle className="h-12 w-12 text-[var(--status-danger)] mx-auto mb-4" aria-hidden="true" />
-          <h3 className="text-lg font-semibold text-foreground mb-2">
+          <h2 className="text-lg font-semibold text-foreground mb-2">
             Failed to Load Data
-          </h3>
+          </h2>
           <p className="text-sm text-muted-foreground mb-4">{error}</p>
           <button
             onClick={() => loadData()}

--- a/muscatbay/app/app/settings/page.tsx
+++ b/muscatbay/app/app/settings/page.tsx
@@ -246,6 +246,7 @@ export default function SettingsPage() {
                                         id="avatar-upload"
                                         type="file"
                                         accept="image/*"
+                                        aria-label="Upload avatar"
                                         className="hidden"
                                         onChange={handleAvatarChange}
                                     />

--- a/muscatbay/app/components/layout/bottom-nav.tsx
+++ b/muscatbay/app/components/layout/bottom-nav.tsx
@@ -241,7 +241,7 @@ export function BottomNav() {
                 `}
               >
                 <Icon className="w-5 h-5" />
-                <span className={`text-[10px] leading-tight ${active ? 'font-semibold' : 'font-medium'}`}>
+                <span className={`text-[11px] leading-tight ${active ? 'font-semibold' : 'font-medium'}`}>
                   {item.name}
                 </span>
                 {active && (
@@ -266,7 +266,7 @@ export function BottomNav() {
             aria-expanded={drawerOpen}
           >
             <MoreHorizontal className="w-5 h-5" />
-            <span className={`text-[10px] leading-tight ${drawerOpen || isOverflowActive ? 'font-semibold' : 'font-medium'}`}>
+            <span className={`text-[11px] leading-tight ${drawerOpen || isOverflowActive ? 'font-semibold' : 'font-medium'}`}>
               More
             </span>
             {isOverflowActive && !drawerOpen && (

--- a/muscatbay/app/components/pwa/register-sw.tsx
+++ b/muscatbay/app/components/pwa/register-sw.tsx
@@ -6,6 +6,34 @@ export function RegisterSW() {
   useEffect(() => {
     if (!("serviceWorker" in navigator)) return;
 
+    // In development the service worker is pure downside: the rebuild-heavy
+    // dev loop regenerates hashed `_next/` chunks constantly, and a cached app
+    // shell that still references now-deleted chunks makes those chunk requests
+    // 404 — the bundle never loads, React never hydrates, and the app hangs on
+    // the splash screen forever (the auto-reload rescue below can't fire because
+    // it needs hydration to run). Never register the SW in dev, and proactively
+    // tear down any SW + caches a previous run (or a visited preview/prod build)
+    // left behind on this origin, so a stranded developer self-heals on reload.
+    if (process.env.NODE_ENV !== "production") {
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((registrations) => {
+          registrations.forEach((registration) => registration.unregister());
+        })
+        .catch(() => {
+          /* silent */
+        });
+      if ("caches" in window) {
+        caches
+          .keys()
+          .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+          .catch(() => {
+            /* silent */
+          });
+      }
+      return;
+    }
+
     // Only auto-reload when a PREVIOUS controller is being replaced by a
     // new SW. On a brand-new visit there is no controller yet, so skip the
     // reload — otherwise every first-time visitor would flash a reload.

--- a/muscatbay/app/components/shared/data-table/multi-select-dropdown.tsx
+++ b/muscatbay/app/components/shared/data-table/multi-select-dropdown.tsx
@@ -98,14 +98,14 @@ export function MultiSelectDropdown({
                         <div className="flex items-center justify-between px-3 py-2 border-b border-border/70">
                             <button
                                 onClick={selectAll}
-                                className="text-xs font-medium text-primary hover:text-primary/80 transition-colors min-h-[36px] px-1 flex items-center"
+                                className="text-xs font-medium text-primary hover:text-primary/80 transition-colors min-h-[36px] pointer-coarse:min-h-11 px-1 flex items-center"
                             >
                                 Select All
                             </button>
                             <span className="text-border select-none text-xs">|</span>
                             <button
                                 onClick={clearAll}
-                                className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors min-h-[36px] px-1 flex items-center"
+                                className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors min-h-[36px] pointer-coarse:min-h-11 px-1 flex items-center"
                             >
                                 Clear
                             </button>

--- a/muscatbay/app/components/shared/data-table/table-toolbar.tsx
+++ b/muscatbay/app/components/shared/data-table/table-toolbar.tsx
@@ -90,7 +90,7 @@ export function DensityToggle({ density, onChange, className }: DensityTogglePro
                     title={label}
                     aria-pressed={density === value}
                     className={cn(
-                        "flex items-center justify-center w-8 h-8 transition-colors duration-150",
+                        "flex items-center justify-center w-8 h-8 pointer-coarse:min-h-11 pointer-coarse:min-w-11 transition-colors duration-150",
                         density === value
                             ? "bg-primary text-primary-foreground"
                             : "text-muted-foreground/70 hover:bg-muted hover:text-foreground"

--- a/muscatbay/app/components/ui/splash-screen.tsx
+++ b/muscatbay/app/components/ui/splash-screen.tsx
@@ -57,6 +57,9 @@ export function SplashScreen({ exiting = false }: SplashScreenProps) {
         className="mt-8 flex flex-col items-center gap-1"
         style={{ animation: "fadeInUp 450ms ease-out 200ms both" }}
       >
+        {/* text-white is intentional: the splash bg is always the dark brand
+            surface (--mb-splash-bg) regardless of theme, so white is the
+            correct, fully-legible foreground in both light and dark mode. */}
         <p className="text-base font-semibold tracking-[0.22em] text-white uppercase select-none">
           Muscat Bay
         </p>

--- a/muscatbay/app/components/water/CSVUploadDialog.tsx
+++ b/muscatbay/app/components/water/CSVUploadDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, type KeyboardEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -149,6 +149,19 @@ export function CSVUploadDialog({ month, year, onUploadComplete }: CSVUploadDial
         fileInputRef.current?.click();
     }, []);
 
+    const isUploadInteractive = uploadState === 'idle' || uploadState === 'error';
+
+    const handleDropZoneKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLDivElement>) => {
+            if (!isUploadInteractive) return;
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                handleClickUpload();
+            }
+        },
+        [isUploadInteractive, handleClickUpload]
+    );
+
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
             <DialogTrigger
@@ -174,12 +187,18 @@ export function CSVUploadDialog({ month, year, onUploadComplete }: CSVUploadDial
                 <div className="mt-4 space-y-4">
                     {/* Drop Zone */}
                     <div
+                        role="button"
+                        tabIndex={isUploadInteractive ? 0 : -1}
+                        aria-label="Upload CSV file — drag and drop or activate to browse"
+                        aria-disabled={!isUploadInteractive}
                         onDragOver={handleDragOver}
                         onDragLeave={handleDragLeave}
                         onDrop={handleDrop}
-                        onClick={uploadState === 'idle' || uploadState === 'error' ? handleClickUpload : undefined}
+                        onClick={isUploadInteractive ? handleClickUpload : undefined}
+                        onKeyDown={handleDropZoneKeyDown}
                         className={cn(
                             "relative border-2 border-dashed rounded-lg p-8 text-center transition-all duration-200 cursor-pointer",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                             uploadState === 'idle' && "border-border dark:border-border hover:border-primary hover:bg-primary/5",
                             uploadState === 'dragging' && "border-primary bg-primary/10",
                             uploadState === 'uploading' && "border-mb-warning bg-mb-warning-light cursor-wait",

--- a/muscatbay/app/components/water/circular-gauge.tsx
+++ b/muscatbay/app/components/water/circular-gauge.tsx
@@ -63,7 +63,12 @@ export function CircularGauge({
                 {label}
             </div>
             <div className={`relative ${sizeClasses.container}`}>
-                <svg className="w-full h-full transform -rotate-90" viewBox="0 0 160 160">
+                <svg
+                    className="w-full h-full transform -rotate-90"
+                    viewBox="0 0 160 160"
+                    role="img"
+                    aria-label={`${label}: ${percentage.toFixed(1)}%`}
+                >
                     {/* Background circle */}
                     <circle
                         cx="80"
@@ -73,6 +78,7 @@ export function CircularGauge({
                         stroke="currentColor"
                         strokeWidth={sizeClasses.strokeWidth}
                         className="text-border dark:text-foreground"
+                        aria-hidden="true"
                     />
                     {/* Progress circle */}
                     <circle
@@ -88,6 +94,7 @@ export function CircularGauge({
                             strokeDashoffset: strokeDashoffset,
                             transition: 'stroke-dashoffset 0.5s ease-in-out'
                         }}
+                        aria-hidden="true"
                     />
                 </svg>
                 <div className="absolute inset-0 flex flex-col items-center justify-center">

--- a/muscatbay/app/components/water/daily-report/inline-zone-l3-table.tsx
+++ b/muscatbay/app/components/water/daily-report/inline-zone-l3-table.tsx
@@ -26,6 +26,27 @@ import {
 
 export { ZoneL3Table };
 
+// ─── Dark-mode-aware status tokens for DOM cells ─────────────────────────────
+// PALETTE stays for chart-only / HierarchyStatCard props. For table cells we
+// route status colors through CSS variables so they auto-flip in dark mode.
+// `tint(role, pct)` builds a translucent background from the role's base var;
+// the `*Text` vars are the WCAG-tuned foreground colors (light in dark theme).
+type StatusRole = 'primary' | 'info' | 'success' | 'danger';
+const STATUS_BASE: Record<StatusRole, string> = {
+    primary: 'var(--primary)',
+    info: 'var(--mb-info)',
+    success: 'var(--mb-success)',
+    danger: 'var(--mb-danger)',
+};
+const STATUS_TEXT: Record<StatusRole, string> = {
+    primary: 'var(--primary)',
+    info: 'var(--mb-info-text)',
+    success: 'var(--mb-success-text)',
+    danger: 'var(--mb-danger-text)',
+};
+const tint = (role: StatusRole, pct: number) =>
+    `color-mix(in srgb, ${STATUS_BASE[role]} ${pct}%, transparent)`;
+
 // ─── Zone L3 Meters Table — All-Days View ────────────────────────────────────
 
 function ZoneL3Table({
@@ -318,16 +339,16 @@ function ZoneL3Table({
                         <TableRow
                             className="border-b-2"
                             style={{
-                                backgroundColor: `${PALETTE.primary}14`,
-                                borderBottomColor: `${PALETTE.primary}40`,
+                                backgroundColor: tint('primary', 8),
+                                borderBottomColor: tint('primary', 25),
                             }}
                         >
                             <TableCell
                                 className={cn(tdBase, "font-medium sticky left-0 z-10")}
                                 style={{
-                                    backgroundColor: `${PALETTE.primary}14`,
-                                    color: PALETTE.primary,
-                                    boxShadow: `inset 4px 0 0 ${PALETTE.primary}`,
+                                    backgroundColor: tint('primary', 8),
+                                    color: STATUS_TEXT.primary,
+                                    boxShadow: `inset 4px 0 0 ${STATUS_BASE.primary}`,
                                 }}
                             >
                                 <span className="inline-flex items-center gap-2">
@@ -335,7 +356,7 @@ function ZoneL3Table({
                                     {zoneRow.zoneName} Bulk (L2)
                                 </span>
                             </TableCell>
-                            <TableCell className={cn(tdBase, "font-mono text-[11px]")} style={{ color: `${PALETTE.primary}AA` }}>
+                            <TableCell className={cn(tdBase, "font-mono text-[11px]")} style={{ color: `color-mix(in srgb, ${STATUS_TEXT.primary} 67%, transparent)` }}>
                                 {zoneConfig.l2Account}
                             </TableCell>
                             <TableCell className={cn(tdBase, "text-center")}>
@@ -345,7 +366,7 @@ function ZoneL3Table({
                                 <TableCell
                                     key={i}
                                     className={cn(tdBase, "text-right tabular-nums px-2 text-[12px] font-medium")}
-                                    style={{ color: PALETTE.primary }}
+                                    style={{ color: STATUS_TEXT.primary }}
                                 >
                                     {val === null ? (
                                         <span className="text-muted-foreground/70 dark:text-muted-foreground">—</span>
@@ -357,8 +378,8 @@ function ZoneL3Table({
                             <TableCell
                                 className={cn(tdBase, "text-right tabular-nums font-medium")}
                                 style={{
-                                    backgroundColor: `${PALETTE.primary}20`,
-                                    color: PALETTE.primary,
+                                    backgroundColor: tint('primary', 12),
+                                    color: STATUS_TEXT.primary,
                                 }}
                             >
                                 {n(l2GrandTotal)}
@@ -395,7 +416,7 @@ function ZoneL3Table({
                                                     aria-expanded={isExpanded}
                                                     aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${detail.buildingName} L4 meters`}
                                                     className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 -ml-1 hover:bg-muted dark:hover:bg-muted transition-colors"
-                                                    style={{ color: PALETTE.primary }}
+                                                    style={{ color: STATUS_TEXT.primary }}
                                                 >
                                                     {isExpanded
                                                         ? <ChevronDown className="h-3.5 w-3.5 shrink-0" />
@@ -405,7 +426,7 @@ function ZoneL3Table({
                                                 </button>
                                             ) : meter.building ? (
                                                 <>
-                                                    <Building2 className="h-3.5 w-3.5 shrink-0" style={{ color: PALETTE.primary }} />
+                                                    <Building2 className="h-3.5 w-3.5 shrink-0 text-primary" />
                                                     {meter.building.buildingName}
                                                 </>
                                             ) : (
@@ -445,19 +466,17 @@ function ZoneL3Table({
                                     rows.push(
                                         <TableRow
                                             key={`${meter.account}-child-${child.account}`}
-                                            className="border-b border-border/60 dark:border-border/60"
-                                            style={{ backgroundColor: `${PALETTE.neutral}26` }}
+                                            className="border-b border-border/60 dark:border-border/60 bg-muted/40 dark:bg-muted/20"
                                         >
                                             <TableCell
-                                                className={cn(tdBase, "pl-10 font-normal sticky left-0 z-10 text-[13px]")}
+                                                className={cn(tdBase, "pl-10 font-normal sticky left-0 z-10 text-[13px] bg-muted/40 dark:bg-muted/20")}
                                                 style={{
-                                                    backgroundColor: `${PALETTE.neutral}26`,
-                                                    boxShadow: `inset 4px 0 0 ${PALETTE.primary}30`,
+                                                    boxShadow: `inset 4px 0 0 ${tint('primary', 19)}`,
                                                 }}
                                             >
                                                 <span className="inline-flex items-center gap-2 text-muted-foreground dark:text-muted-foreground/70">
                                                     {idx === detail.children.length - 1
-                                                        ? <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: PALETTE.primary }} />
+                                                        ? <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: STATUS_BASE.primary }} />
                                                         : <span className="inline-block w-2 h-2 rounded-full bg-border dark:bg-muted" />}
                                                     {child.label}
                                                 </span>
@@ -491,14 +510,14 @@ function ZoneL3Table({
                                 rows.push(
                                     <TableRow
                                         key={`${meter.account}-l4sum`}
-                                        style={{ backgroundColor: `${PALETTE.blue}12` }}
+                                        style={{ backgroundColor: tint('info', 7) }}
                                     >
                                         <TableCell
                                             className={cn(tdBase, "pl-10 font-medium sticky left-0 z-10 text-[12px]")}
                                             style={{
-                                                backgroundColor: `${PALETTE.blue}12`,
-                                                color: PALETTE.blue,
-                                                boxShadow: `inset 4px 0 0 ${PALETTE.blue}`,
+                                                backgroundColor: tint('info', 7),
+                                                color: STATUS_TEXT.info,
+                                                boxShadow: `inset 4px 0 0 ${STATUS_BASE.info}`,
                                             }}
                                             colSpan={3}
                                         >
@@ -508,14 +527,14 @@ function ZoneL3Table({
                                             <TableCell
                                                 key={i}
                                                 className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                                style={{ color: PALETTE.blue }}
+                                                style={{ color: STATUS_TEXT.info }}
                                             >
                                                 {n(t)}
                                             </TableCell>
                                         ))}
                                         <TableCell
                                             className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                            style={{ backgroundColor: `${PALETTE.blue}20`, color: PALETTE.blue }}
+                                            style={{ backgroundColor: tint('info', 12), color: STATUS_TEXT.info }}
                                         >
                                             {n(detail.childGrandTotal)}
                                         </TableCell>
@@ -524,22 +543,22 @@ function ZoneL3Table({
 
                                 // Difference sub-footer — bulk − sum
                                 const isHighBuildingDiff = Math.abs(detail.diffGrandTotal) > 5;
-                                const diffTint = isHighBuildingDiff ? PALETTE.red : PALETTE.mint;
+                                const diffRole: StatusRole = isHighBuildingDiff ? 'danger' : 'success';
                                 rows.push(
                                     <TableRow
                                         key={`${meter.account}-l4diff`}
                                         className="border-b-2"
                                         style={{
-                                            backgroundColor: `${diffTint}14`,
-                                            borderBottomColor: `${diffTint}40`,
+                                            backgroundColor: tint(diffRole, 8),
+                                            borderBottomColor: tint(diffRole, 25),
                                         }}
                                     >
                                         <TableCell
                                             className={cn(tdBase, "pl-10 font-medium sticky left-0 z-10 text-[12px]")}
                                             style={{
-                                                backgroundColor: `${diffTint}14`,
-                                                color: diffTint,
-                                                boxShadow: `inset 4px 0 0 ${diffTint}`,
+                                                backgroundColor: tint(diffRole, 8),
+                                                color: STATUS_TEXT[diffRole],
+                                                boxShadow: `inset 4px 0 0 ${STATUS_BASE[diffRole]}`,
                                             }}
                                             colSpan={3}
                                         >
@@ -549,14 +568,14 @@ function ZoneL3Table({
                                             <TableCell
                                                 key={i}
                                                 className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                                style={{ color: diffTint }}
+                                                style={{ color: STATUS_TEXT[diffRole] }}
                                             >
                                                 {diffCell(t)}
                                             </TableCell>
                                         ))}
                                         <TableCell
                                             className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                            style={{ backgroundColor: `${diffTint}20`, color: diffTint }}
+                                            style={{ backgroundColor: tint(diffRole, 12), color: STATUS_TEXT[diffRole] }}
                                         >
                                             {diffCell(detail.diffGrandTotal)}
                                         </TableCell>
@@ -571,17 +590,17 @@ function ZoneL3Table({
                         <TableRow
                             className="border-t-2"
                             style={{
-                                backgroundColor: `${PALETTE.blue}12`,
-                                borderTopColor: `${PALETTE.blue}40`,
+                                backgroundColor: tint('info', 7),
+                                borderTopColor: tint('info', 25),
                             }}
                         >
                             <TableCell
                                 className={cn(tdBase, "font-medium sticky left-0 z-10")}
                                 colSpan={3}
                                 style={{
-                                    backgroundColor: `${PALETTE.blue}12`,
-                                    color: PALETTE.blue,
-                                    boxShadow: `inset 4px 0 0 ${PALETTE.blue}`,
+                                    backgroundColor: tint('info', 7),
+                                    color: STATUS_TEXT.info,
+                                    boxShadow: `inset 4px 0 0 ${STATUS_BASE.info}`,
                                 }}
                             >
                                 Σ Individuals — {l3Meters.length} meters
@@ -590,14 +609,14 @@ function ZoneL3Table({
                                 <TableCell
                                     key={i}
                                     className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                    style={{ color: PALETTE.blue }}
+                                    style={{ color: STATUS_TEXT.info }}
                                 >
                                     {n(t)}
                                 </TableCell>
                             ))}
                             <TableCell
                                 className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                style={{ backgroundColor: `${PALETTE.blue}20`, color: PALETTE.blue }}
+                                style={{ backgroundColor: tint('info', 12), color: STATUS_TEXT.info }}
                             >
                                 {n(grandTotal)}
                             </TableCell>
@@ -606,22 +625,22 @@ function ZoneL3Table({
                         {/* ── Difference footer row (zone level) ─────────── */}
                         {(() => {
                             const isHighZoneDiff = Math.abs(diffGrandTotal) > 20;
-                            const diffTint = isHighZoneDiff ? PALETTE.red : PALETTE.mint;
+                            const diffRole: StatusRole = isHighZoneDiff ? 'danger' : 'success';
                             return (
                                 <TableRow
                                     className="border-t"
                                     style={{
-                                        backgroundColor: `${diffTint}14`,
-                                        borderTopColor: `${diffTint}40`,
+                                        backgroundColor: tint(diffRole, 8),
+                                        borderTopColor: tint(diffRole, 25),
                                     }}
                                 >
                                     <TableCell
                                         className={cn(tdBase, "font-medium sticky left-0 z-10")}
                                         colSpan={3}
                                         style={{
-                                            backgroundColor: `${diffTint}14`,
-                                            color: diffTint,
-                                            boxShadow: `inset 4px 0 0 ${diffTint}`,
+                                            backgroundColor: tint(diffRole, 8),
+                                            color: STATUS_TEXT[diffRole],
+                                            boxShadow: `inset 4px 0 0 ${STATUS_BASE[diffRole]}`,
                                         }}
                                     >
                                         Difference (L2 − Σ Individuals)
@@ -630,14 +649,14 @@ function ZoneL3Table({
                                         <TableCell
                                             key={i}
                                             className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                            style={{ color: diffTint }}
+                                            style={{ color: STATUS_TEXT[diffRole] }}
                                         >
                                             {diffCell(t)}
                                         </TableCell>
                                     ))}
                                     <TableCell
                                         className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                        style={{ backgroundColor: `${diffTint}20`, color: diffTint }}
+                                        style={{ backgroundColor: tint(diffRole, 12), color: STATUS_TEXT[diffRole] }}
                                     >
                                         {diffCell(diffGrandTotal)}
                                     </TableCell>

--- a/muscatbay/app/components/water/daily-report/zone-panel.tsx
+++ b/muscatbay/app/components/water/daily-report/zone-panel.tsx
@@ -21,6 +21,27 @@ import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@
 
 // ZoneAnalyticsPanel extracted to zone-analytics.tsx
 
+// ─── Dark-mode-aware status tokens for DOM cells ─────────────────────────────
+// PALETTE stays for chart-only / HierarchyStatCard props. For table cells we
+// route status colors through CSS variables so they auto-flip in dark mode.
+// `tint(role, pct)` builds a translucent background from the role's base var;
+// the `*Text` vars are the WCAG-tuned foreground colors (light in dark theme).
+type StatusRole = 'primary' | 'info' | 'success' | 'danger';
+const STATUS_BASE: Record<StatusRole, string> = {
+    primary: 'var(--primary)',
+    info: 'var(--mb-info)',
+    success: 'var(--mb-success)',
+    danger: 'var(--mb-danger)',
+};
+const STATUS_TEXT: Record<StatusRole, string> = {
+    primary: 'var(--primary)',
+    info: 'var(--mb-info-text)',
+    success: 'var(--mb-success-text)',
+    danger: 'var(--mb-danger-text)',
+};
+const tint = (role: StatusRole, pct: number) =>
+    `color-mix(in srgb, ${STATUS_BASE[role]} ${pct}%, transparent)`;
+
 // ─── Zone L3 Meters Table — All-Days View ────────────────────────────────────
 
 export function ZoneL3Table({
@@ -313,16 +334,16 @@ export function ZoneL3Table({
                             <TableRow
                                 className="border-b-2"
                                 style={{
-                                    backgroundColor: `${PALETTE.primary}14`,
-                                    borderBottomColor: `${PALETTE.primary}40`,
+                                    backgroundColor: tint('primary', 8),
+                                    borderBottomColor: tint('primary', 25),
                                 }}
                             >
                                 <TableCell
                                     className={cn(tdBase, "font-medium sticky left-0 z-10")}
                                     style={{
-                                        backgroundColor: `${PALETTE.primary}14`,
-                                        color: PALETTE.primary,
-                                        boxShadow: `inset 4px 0 0 ${PALETTE.primary}`,
+                                        backgroundColor: tint('primary', 8),
+                                        color: STATUS_TEXT.primary,
+                                        boxShadow: `inset 4px 0 0 ${STATUS_BASE.primary}`,
                                     }}
                                 >
                                     <span className="inline-flex items-center gap-2">
@@ -330,7 +351,7 @@ export function ZoneL3Table({
                                         {zoneRow.zoneName} Bulk (L2)
                                     </span>
                                 </TableCell>
-                                <TableCell className={cn(tdBase, "font-mono text-[11px]")} style={{ color: `${PALETTE.primary}AA` }}>
+                                <TableCell className={cn(tdBase, "font-mono text-[11px]")} style={{ color: `color-mix(in srgb, ${STATUS_TEXT.primary} 67%, transparent)` }}>
                                     {zoneConfig.l2Account}
                                 </TableCell>
                                 <TableCell className={cn(tdBase, "text-center")}>
@@ -340,7 +361,7 @@ export function ZoneL3Table({
                                     <TableCell
                                         key={i}
                                         className={cn(tdBase, "text-right tabular-nums px-2 text-[12px] font-medium")}
-                                        style={{ color: PALETTE.primary }}
+                                        style={{ color: STATUS_TEXT.primary }}
                                     >
                                         {val === null ? (
                                             <span className="text-muted-foreground/70 dark:text-muted-foreground">—</span>
@@ -352,8 +373,8 @@ export function ZoneL3Table({
                                 <TableCell
                                     className={cn(tdBase, "text-right tabular-nums font-medium")}
                                     style={{
-                                        backgroundColor: `${PALETTE.primary}20`,
-                                        color: PALETTE.primary,
+                                        backgroundColor: tint('primary', 12),
+                                        color: STATUS_TEXT.primary,
                                     }}
                                 >
                                     {n(l2GrandTotal)}
@@ -390,7 +411,7 @@ export function ZoneL3Table({
                                                         aria-expanded={isExpanded}
                                                         aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${detail.buildingName} L4 meters`}
                                                         className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 -ml-1 hover:bg-muted dark:hover:bg-muted transition-colors"
-                                                        style={{ color: PALETTE.primary }}
+                                                        style={{ color: STATUS_TEXT.primary }}
                                                     >
                                                         {isExpanded
                                                             ? <ChevronDown className="h-3.5 w-3.5 shrink-0" />
@@ -400,7 +421,7 @@ export function ZoneL3Table({
                                                     </button>
                                                 ) : meter.building ? (
                                                     <>
-                                                        <Building2 className="h-3.5 w-3.5 shrink-0" style={{ color: PALETTE.primary }} />
+                                                        <Building2 className="h-3.5 w-3.5 shrink-0 text-primary" />
                                                         {meter.building.buildingName}
                                                     </>
                                                 ) : (
@@ -440,19 +461,17 @@ export function ZoneL3Table({
                                         rows.push(
                                             <TableRow
                                                 key={`${meter.account}-child-${child.account}`}
-                                                className="border-b border-border/60 dark:border-border/60"
-                                                style={{ backgroundColor: `${PALETTE.neutral}26` }}
+                                                className="border-b border-border/60 dark:border-border/60 bg-muted/40 dark:bg-muted/20"
                                             >
                                                 <TableCell
-                                                    className={cn(tdBase, "pl-10 font-normal sticky left-0 z-10 text-[13px]")}
+                                                    className={cn(tdBase, "pl-10 font-normal sticky left-0 z-10 text-[13px] bg-muted/40 dark:bg-muted/20")}
                                                     style={{
-                                                        backgroundColor: `${PALETTE.neutral}26`,
-                                                        boxShadow: `inset 4px 0 0 ${PALETTE.primary}30`,
+                                                        boxShadow: `inset 4px 0 0 ${tint('primary', 19)}`,
                                                     }}
                                                 >
                                                     <span className="inline-flex items-center gap-2 text-muted-foreground dark:text-muted-foreground/70">
                                                         {idx === detail.children.length - 1
-                                                            ? <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: PALETTE.primary }} />
+                                                            ? <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: STATUS_BASE.primary }} />
                                                             : <span className="inline-block w-2 h-2 rounded-full bg-border dark:bg-muted" />}
                                                         {child.label}
                                                     </span>
@@ -486,14 +505,14 @@ export function ZoneL3Table({
                                     rows.push(
                                         <TableRow
                                             key={`${meter.account}-l4sum`}
-                                            style={{ backgroundColor: `${PALETTE.blue}12` }}
+                                            style={{ backgroundColor: tint('info', 7) }}
                                         >
                                             <TableCell
                                                 className={cn(tdBase, "pl-10 font-medium sticky left-0 z-10 text-[12px]")}
                                                 style={{
-                                                    backgroundColor: `${PALETTE.blue}12`,
-                                                    color: PALETTE.blue,
-                                                    boxShadow: `inset 4px 0 0 ${PALETTE.blue}`,
+                                                    backgroundColor: tint('info', 7),
+                                                    color: STATUS_TEXT.info,
+                                                    boxShadow: `inset 4px 0 0 ${STATUS_BASE.info}`,
                                                 }}
                                                 colSpan={3}
                                             >
@@ -503,14 +522,14 @@ export function ZoneL3Table({
                                                 <TableCell
                                                     key={i}
                                                     className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                                    style={{ color: PALETTE.blue }}
+                                                    style={{ color: STATUS_TEXT.info }}
                                                 >
                                                     {n(t)}
                                                 </TableCell>
                                             ))}
                                             <TableCell
                                                 className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                                style={{ backgroundColor: `${PALETTE.blue}20`, color: PALETTE.blue }}
+                                                style={{ backgroundColor: tint('info', 12), color: STATUS_TEXT.info }}
                                             >
                                                 {n(detail.childGrandTotal)}
                                             </TableCell>
@@ -519,22 +538,22 @@ export function ZoneL3Table({
 
                                     // Difference sub-footer — bulk − sum
                                     const isHighBuildingDiff = Math.abs(detail.diffGrandTotal) > 5;
-                                    const diffTint = isHighBuildingDiff ? PALETTE.red : PALETTE.mint;
+                                    const diffRole: StatusRole = isHighBuildingDiff ? 'danger' : 'success';
                                     rows.push(
                                         <TableRow
                                             key={`${meter.account}-l4diff`}
                                             className="border-b-2"
                                             style={{
-                                                backgroundColor: `${diffTint}14`,
-                                                borderBottomColor: `${diffTint}40`,
+                                                backgroundColor: tint(diffRole, 8),
+                                                borderBottomColor: tint(diffRole, 25),
                                             }}
                                         >
                                             <TableCell
                                                 className={cn(tdBase, "pl-10 font-medium sticky left-0 z-10 text-[12px]")}
                                                 style={{
-                                                    backgroundColor: `${diffTint}14`,
-                                                    color: diffTint,
-                                                    boxShadow: `inset 4px 0 0 ${diffTint}`,
+                                                    backgroundColor: tint(diffRole, 8),
+                                                    color: STATUS_TEXT[diffRole],
+                                                    boxShadow: `inset 4px 0 0 ${STATUS_BASE[diffRole]}`,
                                                 }}
                                                 colSpan={3}
                                             >
@@ -544,14 +563,14 @@ export function ZoneL3Table({
                                                 <TableCell
                                                     key={i}
                                                     className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                                    style={{ color: diffTint }}
+                                                    style={{ color: STATUS_TEXT[diffRole] }}
                                                 >
                                                     {diffCell(t)}
                                                 </TableCell>
                                             ))}
                                             <TableCell
                                                 className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                                style={{ backgroundColor: `${diffTint}20`, color: diffTint }}
+                                                style={{ backgroundColor: tint(diffRole, 12), color: STATUS_TEXT[diffRole] }}
                                             >
                                                 {diffCell(detail.diffGrandTotal)}
                                             </TableCell>
@@ -566,17 +585,17 @@ export function ZoneL3Table({
                             <TableRow
                                 className="border-t-2"
                                 style={{
-                                    backgroundColor: `${PALETTE.blue}12`,
-                                    borderTopColor: `${PALETTE.blue}40`,
+                                    backgroundColor: tint('info', 7),
+                                    borderTopColor: tint('info', 25),
                                 }}
                             >
                                 <TableCell
                                     className={cn(tdBase, "font-medium sticky left-0 z-10")}
                                     colSpan={3}
                                     style={{
-                                        backgroundColor: `${PALETTE.blue}12`,
-                                        color: PALETTE.blue,
-                                        boxShadow: `inset 4px 0 0 ${PALETTE.blue}`,
+                                        backgroundColor: tint('info', 7),
+                                        color: STATUS_TEXT.info,
+                                        boxShadow: `inset 4px 0 0 ${STATUS_BASE.info}`,
                                     }}
                                 >
                                     Σ Individuals — {l3Meters.length} meters
@@ -585,14 +604,14 @@ export function ZoneL3Table({
                                     <TableCell
                                         key={i}
                                         className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                        style={{ color: PALETTE.blue }}
+                                        style={{ color: STATUS_TEXT.info }}
                                     >
                                         {n(t)}
                                     </TableCell>
                                 ))}
                                 <TableCell
                                     className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                    style={{ backgroundColor: `${PALETTE.blue}20`, color: PALETTE.blue }}
+                                    style={{ backgroundColor: tint('info', 12), color: STATUS_TEXT.info }}
                                 >
                                     {n(grandTotal)}
                                 </TableCell>
@@ -601,22 +620,22 @@ export function ZoneL3Table({
                             {/* ── Difference footer row (zone level) ─────────── */}
                             {(() => {
                                 const isHighZoneDiff = Math.abs(diffGrandTotal) > 20;
-                                const diffTint = isHighZoneDiff ? PALETTE.red : PALETTE.mint;
+                                const diffRole: StatusRole = isHighZoneDiff ? 'danger' : 'success';
                                 return (
                                     <TableRow
                                         className="border-t"
                                         style={{
-                                            backgroundColor: `${diffTint}14`,
-                                            borderTopColor: `${diffTint}40`,
+                                            backgroundColor: tint(diffRole, 8),
+                                            borderTopColor: tint(diffRole, 25),
                                         }}
                                     >
                                         <TableCell
                                             className={cn(tdBase, "font-medium sticky left-0 z-10")}
                                             colSpan={3}
                                             style={{
-                                                backgroundColor: `${diffTint}14`,
-                                                color: diffTint,
-                                                boxShadow: `inset 4px 0 0 ${diffTint}`,
+                                                backgroundColor: tint(diffRole, 8),
+                                                color: STATUS_TEXT[diffRole],
+                                                boxShadow: `inset 4px 0 0 ${STATUS_BASE[diffRole]}`,
                                             }}
                                         >
                                             Difference (L2 − Σ Individuals)
@@ -625,14 +644,14 @@ export function ZoneL3Table({
                                             <TableCell
                                                 key={i}
                                                 className={cn(tdBase, "text-right tabular-nums font-medium px-2 text-[12px]")}
-                                                style={{ color: diffTint }}
+                                                style={{ color: STATUS_TEXT[diffRole] }}
                                             >
                                                 {diffCell(t)}
                                             </TableCell>
                                         ))}
                                         <TableCell
                                             className={cn(tdBase, "text-right tabular-nums font-medium")}
-                                            style={{ backgroundColor: `${diffTint}20`, color: diffTint }}
+                                            style={{ backgroundColor: tint(diffRole, 12), color: STATUS_TEXT[diffRole] }}
                                         >
                                             {diffCell(diffGrandTotal)}
                                         </TableCell>

--- a/muscatbay/app/components/water/date-range-picker.tsx
+++ b/muscatbay/app/components/water/date-range-picker.tsx
@@ -140,11 +140,13 @@ function DualRangeSlider({ min, max, value, onValueChange, startLabel, endLabel 
             className="relative flex items-center w-full h-5 cursor-pointer touch-none select-none overflow-visible"
             onClick={handleTrackClick}
         >
-            {/* Track background */}
-            <div className="absolute inset-x-0 h-2 rounded-full bg-border dark:bg-muted" />
-            {/* Active range */}
+            {/* Track background — lifted off the dark card surface (--muted #22202A is
+                nearly indistinguishable from --card #16141B) so the inactive portion of
+                the track stays visible and the active range reads as a clear contrast. */}
+            <div className="absolute inset-x-0 h-2 rounded-full bg-border dark:bg-muted-foreground/30" />
+            {/* Active range — brand teal is bright in both themes; pinned explicitly for dark. */}
             <div
-                className="absolute h-2 rounded-full bg-secondary"
+                className="absolute h-2 rounded-full bg-secondary dark:bg-secondary"
                 style={{ left: `${startPct}%`, right: `${100 - endPct}%` }}
             />
             {/* Start thumb */}

--- a/muscatbay/app/components/water/monthly/water-monthly-dashboard.tsx
+++ b/muscatbay/app/components/water/monthly/water-monthly-dashboard.tsx
@@ -17,7 +17,7 @@
  * @module components/water/monthly/water-monthly-dashboard
  */
 
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type MouseEvent, type ReactNode } from "react";
 import {
     ResponsiveContainer, ComposedChart, BarChart, Bar, Line, Area, AreaChart,
     XAxis, YAxis, CartesianGrid, Tooltip, Legend, PieChart, Pie, Cell, ReferenceLine,
@@ -65,6 +65,15 @@ const TIP = {
     background: "var(--wm-card)", color: "var(--wm-ink)", border: "1px solid var(--wm-border)",
 } as const;
 
+/* ---------- stable Recharts formatters (module-level: identity-stable across renders) ----------
+ * Param types mirror Recharts' Formatter signature (value may be a number/string/array or undefined,
+ * name is string | number) so these are assignable to <Tooltip formatter={...}> without casts. */
+type TipValue = number | string | ReadonlyArray<number | string> | undefined;
+const fmtSupplyConsLoss = (v: TipValue, n: number | string | undefined): [string, string] => [fmt(Number(v)) + (n === "target" ? "%" : " m³"), String(n)];
+const fmtM3 = (v: TipValue, n: number | string | undefined): [string, string] => [fmt(Number(v)) + " m³", String(n)];
+const fmtConsumptionM3 = (v: TipValue): [string, string] => [fmt(Number(v)) + " m³", "Consumption"];
+const fmtLossPctPlain = (v: TipValue): [string, string] => [String(v) + "%", "Loss"];
+
 /* ---------- UI atoms ---------- */
 interface KpiProps {
     icon: LucideIcon;
@@ -78,7 +87,7 @@ interface KpiProps {
 }
 function Kpi({ icon: Icon, label, value, unit, sub, bg, ic, delta }: KpiProps) {
     return (
-        <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: RADIUS.card, boxShadow: SHADOW }} className="p-4 transition-all">
+        <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: RADIUS.card, boxShadow: SHADOW }} className="p-4 transition-shadow">
             <div className="flex items-start justify-between">
                 <div className="flex items-center gap-3">
                     <div className="w-10 h-10 flex items-center justify-center shrink-0" style={{ background: bg, borderRadius: RADIUS.md }}>
@@ -92,7 +101,7 @@ function Kpi({ icon: Icon, label, value, unit, sub, bg, ic, delta }: KpiProps) {
                     </div>
                 </div>
                 {delta && (
-                    <div className="flex items-center gap-1 text-xs font-semibold" style={{ color: delta.up ? "#B85C5C" : "#5E8C77" }}>
+                    <div className={`flex items-center gap-1 text-xs font-semibold ${delta.up ? "text-mb-danger-text" : "text-mb-success-text"}`}>
                         {delta.up ? <TrendingUp className="w-3.5 h-3.5" /> : <TrendingDown className="w-3.5 h-3.5" />}{delta.text}
                     </div>
                 )}
@@ -185,8 +194,8 @@ function LossLink({ label, v, of }: { label: string; v: number; of: number }) {
     return (
         <div className="flex flex-col items-center shrink-0 px-0.5">
             <ArrowRight className="w-4 h-4" style={{ color: C.muted }} />
-            <span className="px-1.5 py-0.5 rounded text-[11px] font-bold mt-1 whitespace-nowrap" style={{ background: "#FDECEC", color: "#D12E2E" }}>−{fmt(v)} m³</span>
-            <span className="text-[10px] mt-0.5 whitespace-nowrap font-semibold" style={{ color: "#D12E2E" }}>{label} · {p}%</span>
+            <span className="px-1.5 py-0.5 rounded text-[11px] font-bold mt-1 whitespace-nowrap bg-mb-danger-light text-mb-danger-text">−{fmt(v)} m³</span>
+            <span className="text-[10px] mt-0.5 whitespace-nowrap font-semibold text-mb-danger-text">{label} · {p}%</span>
         </div>
     );
 }
@@ -286,9 +295,9 @@ function Overview({ period: t, monthly, sel, lossDelta, periodLabel }: OverviewP
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
                 <Kpi icon={Droplet} label="Total Supply (A1)" value={fmt(t.A1)} unit="m³" bg="var(--chart-bg-blue)" ic="#3B7ED2" sub={periodLabel} />
                 <Kpi icon={Droplet} label="Distribution (A2)" value={fmt(t.A2)} unit="m³" bg="var(--chart-bg-cyan)" ic="#6B9AC4" sub="Zone bulk + direct" />
-                <Kpi icon={CheckCircle2} label="Consumption (A3)" value={fmt(t.A3)} unit="m³" bg="var(--chart-bg-green)" ic="#5E8C77" sub="Billed at end-user" />
-                <Kpi icon={Gauge} label="Efficiency" value={`${efficiency}%`} bg="var(--chart-bg-green)" ic="#5E8C77" sub={`Target ≥ ${100 - TARGET_LOSS_PCT}%`} />
-                <Kpi icon={AlertTriangle} label="Total Loss" value={fmt(t.loss)} unit="m³" bg="var(--chart-bg-red)" ic="#B85C5C" sub={`${t.lossPct}% of supply`} delta={lossDelta} />
+                <Kpi icon={CheckCircle2} label="Consumption (A3)" value={fmt(t.A3)} unit="m³" bg="var(--chart-bg-green)" ic="var(--mb-success-text)" sub="Billed at end-user" />
+                <Kpi icon={Gauge} label="Efficiency" value={`${efficiency}%`} bg="var(--chart-bg-green)" ic="var(--mb-success-text)" sub={`Target ≥ ${100 - TARGET_LOSS_PCT}%`} />
+                <Kpi icon={AlertTriangle} label="Total Loss" value={fmt(t.loss)} unit="m³" bg="var(--chart-bg-red)" ic="var(--mb-danger-text)" sub={`${t.lossPct}% of supply`} delta={lossDelta} />
                 <Kpi icon={FileSpreadsheet} label="Loss Cost Estimate" value={fmt(lossCost)} unit="OMR" bg="var(--chart-bg-orange)" ic="#B5703A" sub={`${LOSS_RATE_OMR} OMR / m³ assumption`} />
             </div>
 
@@ -302,11 +311,11 @@ function Overview({ period: t, monthly, sel, lossDelta, periodLabel }: OverviewP
                     <RingGauge frac={a3f} color={C.cons} big={fmt(t.A3)} small="m³" label="A3 · Consumption" caption="at meters" />
                 </div>
                 <div className="flex justify-center mt-3 pt-3" style={{ borderTop: `1px solid ${C.border}` }}>
-                    <div className="flex items-center gap-3 px-4 py-2 rounded-lg" style={{ background: t.lossPct > TARGET_LOSS_PCT ? "#FBE2E2" : "#EAF3EE", border: `1px solid ${t.lossPct > TARGET_LOSS_PCT ? "#EEAEAE" : "#BFE1CD"}` }}>
-                        <Target className="w-5 h-5 shrink-0" style={{ color: t.lossPct > TARGET_LOSS_PCT ? "#D12E2E" : "#5E8C77" }} />
+                    <div className={`flex items-center gap-3 px-4 py-2 rounded-lg border ${t.lossPct > TARGET_LOSS_PCT ? "bg-mb-danger-light border-mb-danger" : "bg-mb-success-light border-mb-success"}`}>
+                        <Target className={`w-5 h-5 shrink-0 ${t.lossPct > TARGET_LOSS_PCT ? "text-mb-danger-text" : "text-mb-success-text"}`} />
                         <div className="leading-tight">
-                            <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: "#4E4456" }}>Total System Loss vs 15% Target</p>
-                            <p className="text-lg font-bold" style={{ color: "#4E4456" }}>{fmt(t.loss)} <span className="text-xs font-medium">m³</span> · {t.lossPct}% · {t.lossPct <= TARGET_LOSS_PCT ? "Within target" : `${(t.lossPct - TARGET_LOSS_PCT).toFixed(1)} pp above target`}</p>
+                            <p className="text-[11px] font-semibold uppercase tracking-wide text-primary">Total System Loss vs 15% Target</p>
+                            <p className="text-lg font-bold text-primary">{fmt(t.loss)} <span className="text-xs font-medium">m³</span> · {t.lossPct}% · {t.lossPct <= TARGET_LOSS_PCT ? "Within target" : `${(t.lossPct - TARGET_LOSS_PCT).toFixed(1)} pp above target`}</p>
                         </div>
                     </div>
                 </div>
@@ -320,7 +329,7 @@ function Overview({ period: t, monthly, sel, lossDelta, periodLabel }: OverviewP
                                 <CartesianGrid strokeDasharray="3 3" stroke="var(--wm-track)" />
                                 <XAxis dataKey="m" tick={{ fontSize: 11, fill: C.muted }} />
                                 <YAxis tick={{ fontSize: 11, fill: C.muted }} />
-                                <Tooltip formatter={(v, n) => [fmt(Number(v)) + (n === "target" ? "%" : " m³"), n]} contentStyle={TIP} />
+                                <Tooltip formatter={fmtSupplyConsLoss} contentStyle={TIP} />
                                 <Legend wrapperStyle={{ fontSize: 11, color: "var(--wm-ink)" }} />
                                 {selectedLineMonths.map((i) => <ReferenceLine key={i} x={MONTHS[i]} stroke={C.primary} strokeDasharray="4 4" />)}
                                 <Bar dataKey="A1" name="Supply" fill={C.supply} radius={[3, 3, 0, 0]} barSize={14} />
@@ -357,7 +366,7 @@ function Overview({ period: t, monthly, sel, lossDelta, periodLabel }: OverviewP
                         <CartesianGrid strokeDasharray="3 3" stroke="var(--wm-track)" />
                         <XAxis dataKey="m" tick={{ fontSize: 11, fill: C.muted }} />
                         <YAxis tick={{ fontSize: 11, fill: C.muted }} unit="%" />
-                        <Tooltip formatter={(v) => [v + "%", "Loss"]} contentStyle={TIP} />
+                        <Tooltip formatter={fmtLossPctPlain} contentStyle={TIP} />
                         {selectedLineMonths.map((i) => <ReferenceLine key={i} x={MONTHS[i]} stroke={C.primary} strokeDasharray="4 4" />)}
                         <ReferenceLine y={TARGET_LOSS_PCT} stroke="#D12E2E" strokeDasharray="5 5" label={{ value: "15% target", position: "insideTopRight", fill: "#D12E2E", fontSize: 11 }} />
                         <Area dataKey="lossPct" stroke={C.loss} strokeWidth={2} fill="url(#wm-lg)" />
@@ -380,6 +389,12 @@ interface ZonesViewProps {
 function ZonesView({ data, period, monthly, sel, nMonths, year }: ZonesViewProps) {
     const [zoneSel, setZoneSel] = useState("all");
     const real = period.zones;
+
+    // Stable handler for zone cards — reads the zone key off the clicked button's
+    // data attribute so a single callback replaces a per-item lambda inside .map().
+    const selectZoneFromCard = useCallback((e: MouseEvent<HTMLButtonElement>) => {
+        setZoneSel(e.currentTarget.dataset.zone ?? "all");
+    }, []);
 
     const picker = (
         <div className="flex flex-wrap items-center gap-2 mb-1">
@@ -420,20 +435,20 @@ function ZonesView({ data, period, monthly, sel, nMonths, year }: ZonesViewProps
                 {picker}
                 <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                     <Kpi icon={Droplet} label="Zone Supply" value={fmt(supply)} unit="m³" bg="var(--chart-bg-blue)" ic={C.dist} sub="L2 bulk meter" />
-                    <Kpi icon={CheckCircle2} label="Individual Use" value={fmt(cons)} unit="m³" bg="var(--chart-bg-green)" ic="#5E8C77" sub={`${z.meters} meters`} />
-                    <Kpi icon={AlertTriangle} label="Zone Loss" value={fmt(loss)} unit="m³" bg="var(--chart-bg-red)" ic="#D12E2E" sub="supply − individual" />
+                    <Kpi icon={CheckCircle2} label="Individual Use" value={fmt(cons)} unit="m³" bg="var(--chart-bg-green)" ic="var(--mb-success-text)" sub={`${z.meters} meters`} />
+                    <Kpi icon={AlertTriangle} label="Zone Loss" value={fmt(loss)} unit="m³" bg="var(--chart-bg-red)" ic="var(--mb-danger-text)" sub="supply − individual" />
                     <Kpi icon={Gauge} label="Loss %" value={`${z.lossPct}%`} bg={s.bg} ic={s.c} sub={s.label} />
                 </div>
 
                 <Panel title={`${z.name} — Supply vs Individual Consumption`} icon={Droplet}
                     note="Green is water recorded by individual meters; red is what entered the zone but no meter recorded — the loss.">
                     <div className="flex justify-between text-[11px] mb-1">
-                        <span style={{ color: "#5E8C77" }}>Consumption {fmt(cons)} m³ · {Math.round(consPct)}%</span>
-                        <span className="font-semibold" style={{ color: "#D12E2E" }}>Loss {fmt(loss)} m³ · {z.lossPct}%</span>
+                        <span className="text-mb-success-text">Consumption {fmt(cons)} m³ · {Math.round(consPct)}%</span>
+                        <span className="font-semibold text-mb-danger-text">Loss {fmt(loss)} m³ · {z.lossPct}%</span>
                     </div>
                     <div className="w-full h-8 rounded-md overflow-hidden flex" style={{ background: "var(--wm-track)" }}>
                         <div style={{ width: `${consPct}%`, background: C.cons }} title={`Consumption ${fmt(cons)} m³`} />
-                        <div style={{ width: `${lossBar}%`, background: "#D12E2E" }} title={`Loss ${fmt(loss)} m³`} />
+                        <div style={{ width: `${lossBar}%`, background: "var(--status-danger)" }} title={`Loss ${fmt(loss)} m³`} />
                     </div>
                     <div className="text-[11px] mt-1 text-right" style={{ color: C.muted }}>Zone supply (bulk) {fmt(supply)} m³ · 100%</div>
                 </Panel>
@@ -445,7 +460,7 @@ function ZonesView({ data, period, monthly, sel, nMonths, year }: ZonesViewProps
                                 <CartesianGrid strokeDasharray="3 3" stroke="var(--wm-track)" />
                                 <XAxis dataKey="m" tick={{ fontSize: 11, fill: C.muted }} />
                                 <YAxis tick={{ fontSize: 11, fill: C.muted }} />
-                                <Tooltip formatter={(v, n) => [fmt(Number(v)) + " m³", n]} contentStyle={TIP} />
+                                <Tooltip formatter={fmtM3} contentStyle={TIP} />
                                 <Legend wrapperStyle={{ fontSize: 11, color: "var(--wm-ink)" }} />
                                 {(isRangeSel(sel) ? [sel[0], sel[1]] : sel != null ? [sel] : []).map((i) => <ReferenceLine key={i} x={MONTHS[i]} stroke={C.primary} strokeDasharray="4 4" />)}
                                 <Bar dataKey="Supply" fill={C.dist} radius={[3, 3, 0, 0]} barSize={14} />
@@ -460,7 +475,7 @@ function ZonesView({ data, period, monthly, sel, nMonths, year }: ZonesViewProps
                                 <CartesianGrid strokeDasharray="3 3" stroke="var(--wm-track)" horizontal={false} />
                                 <XAxis type="number" tick={{ fontSize: 10, fill: C.muted }} />
                                 <YAxis type="category" dataKey="name" tick={{ fontSize: 9.5, fill: C.ink }} width={120} />
-                                <Tooltip formatter={(v) => [fmt(Number(v)) + " m³", "Consumption"]} contentStyle={TIP} />
+                                <Tooltip formatter={fmtConsumptionM3} contentStyle={TIP} />
                                 <Bar dataKey="val" fill={C.cons} radius={[0, 4, 4, 0]} barSize={13} />
                             </BarChart>
                         </ResponsiveContainer>
@@ -470,7 +485,7 @@ function ZonesView({ data, period, monthly, sel, nMonths, year }: ZonesViewProps
                 <Panel title={`Individual Meters in ${z.name} (${meters.length})`} icon={Layers} note="Zone supply = Σ individual consumption + loss.">
                     <div className="overflow-auto" style={{ maxHeight: 380 }}>
                         <table className="w-full text-[12px]">
-                            <thead className="sticky top-0 z-10" style={{ background: C.primary, color: "#fff" }}>
+                            <thead className="sticky top-0 z-10" style={{ background: C.primary, color: "var(--primary-foreground)" }}>
                                 <tr>
                                     <th className="text-left px-3 py-2">#</th>
                                     <th className="text-left px-2 py-2">Meter</th>
@@ -492,14 +507,14 @@ function ZonesView({ data, period, monthly, sel, nMonths, year }: ZonesViewProps
                             </tbody>
                             <tfoot>
                                 <tr style={{ borderTop: `2px solid ${C.border}` }}>
-                                    <td colSpan={3} className="px-3 py-1.5 font-semibold" style={{ color: "#5E8C77" }}>Σ Individual consumption</td>
-                                    <td className="px-2 py-1.5 text-right font-bold" style={{ color: "#5E8C77" }}>{fmt1(cons)}</td>
-                                    <td className="px-3 py-1.5 text-right font-bold" style={{ color: "#5E8C77" }}>{Math.round(consPct)}%</td>
+                                    <td colSpan={3} className="px-3 py-1.5 font-semibold text-mb-success-text">Σ Individual consumption</td>
+                                    <td className="px-2 py-1.5 text-right font-bold text-mb-success-text">{fmt1(cons)}</td>
+                                    <td className="px-3 py-1.5 text-right font-bold text-mb-success-text">{Math.round(consPct)}%</td>
                                 </tr>
                                 <tr>
-                                    <td colSpan={3} className="px-3 py-1.5 font-semibold" style={{ color: "#D12E2E" }}>Unaccounted (loss)</td>
-                                    <td className="px-2 py-1.5 text-right font-bold" style={{ color: "#D12E2E" }}>{fmt1(loss)}</td>
-                                    <td className="px-3 py-1.5 text-right font-bold" style={{ color: "#D12E2E" }}>{z.lossPct}%</td>
+                                    <td colSpan={3} className="px-3 py-1.5 font-semibold text-mb-danger-text">Unaccounted (loss)</td>
+                                    <td className="px-2 py-1.5 text-right font-bold text-mb-danger-text">{fmt1(loss)}</td>
+                                    <td className="px-3 py-1.5 text-right font-bold text-mb-danger-text">{z.lossPct}%</td>
                                 </tr>
                                 <tr style={{ borderTop: `1px solid ${C.border}` }}>
                                     <td colSpan={3} className="px-3 py-1.5 font-bold" style={{ color: C.heading }}>Zone supply (bulk)</td>
@@ -578,7 +593,7 @@ function ZonesView({ data, period, monthly, sel, nMonths, year }: ZonesViewProps
                 {real.map((z) => {
                     const s = sev(z.lossPct);
                     return (
-                        <button key={z.zone} onClick={() => setZoneSel(z.zone)} className="text-left p-4 transition-all hover:shadow-md"
+                        <button key={z.zone} data-zone={z.zone} onClick={selectZoneFromCard} className="text-left p-4 transition-shadow hover:shadow-md"
                             style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: RADIUS.card, borderLeft: `4px solid ${s.c}`, boxShadow: SHADOW }}>
                             <div className="flex items-center justify-between">
                                 <h4 className="text-sm font-semibold tracking-tight" style={{ color: C.heading }}>{z.name}</h4>
@@ -662,7 +677,7 @@ function AssetsView({ period }: { period: PeriodResult }) {
                         <CartesianGrid strokeDasharray="3 3" stroke="var(--wm-track)" horizontal={false} />
                         <XAxis type="number" tick={{ fontSize: 10, fill: C.muted }} />
                         <YAxis type="category" dataKey="name" tick={{ fontSize: 9.5, fill: C.ink }} width={140} />
-                        <Tooltip formatter={(v) => [fmt(Number(v)) + " m³", "Consumption"]} contentStyle={TIP} />
+                        <Tooltip formatter={fmtConsumptionM3} contentStyle={TIP} />
                         <Bar dataKey="total" fill={C.accent} radius={[0, 4, 4, 0]} barSize={14} />
                     </BarChart>
                 </ResponsiveContainer>
@@ -720,7 +735,7 @@ function MetersView({ data, year, sel, nMonths }: { data: WaterData; year: strin
                 <Select icon={MapPin} value={zone} setValue={setZone} options={zoneOpts} />
                 <Select icon={Filter} value={level} setValue={setLevel} options={levelOpts} />
                 <Select icon={Layers} value={typ} setValue={setTyp} options={typeOpts} />
-                <button onClick={() => downloadRows(exportData, `water-meter-explorer-${year}.csv`)} className="flex items-center gap-1.5 px-3 py-2 text-sm font-semibold" style={{ background: C.primary, color: "#fff", borderRadius: RADIUS.md }}><Download className="w-4 h-4" />Export CSV</button>
+                <button onClick={() => downloadRows(exportData, `water-meter-explorer-${year}.csv`)} className="flex items-center gap-1.5 px-3 py-2 text-sm font-semibold" style={{ background: C.primary, color: "var(--primary-foreground)", borderRadius: RADIUS.md }}><Download className="w-4 h-4" />Export CSV</button>
                 <button onClick={() => downloadRows(exportData, `water-meter-explorer-${year}-excel.csv`)} className="flex items-center gap-1.5 px-3 py-2 text-sm font-semibold" style={{ background: C.accent, color: C.primary, borderRadius: RADIUS.md }}><FileSpreadsheet className="w-4 h-4" />Excel-ready</button>
                 <span className="text-[12px] ml-auto font-medium" style={{ color: C.muted }}>
                     {rows.length} meters · {sel == null ? "period total" : isRangeSel(sel) ? `${MONTHS[sel[0]]}–${MONTHS[sel[1]]} highlighted` : `${MONTHS[sel]} highlighted`}
@@ -729,13 +744,13 @@ function MetersView({ data, year, sel, nMonths }: { data: WaterData; year: strin
             <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: RADIUS.card, boxShadow: SHADOW }} className="overflow-hidden">
                 <div className="overflow-auto" style={{ maxHeight: 600 }}>
                     <table className="text-[11px] border-collapse w-full">
-                        <thead className="sticky top-0 z-10" style={{ background: C.primary, color: "#fff" }}>
+                        <thead className="sticky top-0 z-10" style={{ background: C.primary, color: "var(--primary-foreground)" }}>
                             <tr>
                                 <th className="text-left px-3 py-2 sticky left-0" style={{ background: C.primary }}>Meter</th>
                                 <th className="px-2 py-2 text-left">Account</th>
                                 <th className="px-2 py-2 text-left">Zone</th><th className="px-2 py-2">Lvl</th><th className="px-2 py-2 text-left">Type</th>
                                 <th className="px-2 py-2 text-right">Selected</th><th className="px-2 py-2 text-left">Flag</th><th className="px-2 py-2 text-left">Last update</th>
-                                {MONTHS.slice(0, nMonths).map((m, i) => (<th key={m} className="px-2 py-2 text-right" style={{ background: monthInSelection(sel, i) ? C.accent : C.primary, color: monthInSelection(sel, i) ? C.primary : "#fff" }}>{m}</th>))}
+                                {MONTHS.slice(0, nMonths).map((m, i) => (<th key={m} className="px-2 py-2 text-right" style={{ background: monthInSelection(sel, i) ? C.accent : C.primary, color: monthInSelection(sel, i) ? C.primary : "var(--primary-foreground)" }}>{m}</th>))}
                             </tr>
                         </thead>
                         <tbody>
@@ -751,9 +766,9 @@ function MetersView({ data, year, sel, nMonths }: { data: WaterData; year: strin
                                         <td className="px-2 py-1.5 text-center"><span className="px-1.5 py-0.5 rounded text-[10px] font-bold text-white" style={{ background: lvlc }}>{m.label}</span></td>
                                         <td className="px-2 py-1.5 whitespace-nowrap" style={{ color: C.muted }}>{(m.typ || "").replace("Residential ", "")}</td>
                                         <td className="px-2 py-1.5 text-right font-bold" style={{ color: C.ink }}>{fmt1(m.shown)}</td>
-                                        <td className="px-2 py-1.5 whitespace-nowrap"><span className="px-2 py-0.5 rounded-full font-semibold" style={{ background: isAlert ? "#FDECEC" : "#EAF3EE", color: isAlert ? "#B85C5C" : "#5E8C77" }}>{m.flags}</span></td>
+                                        <td className="px-2 py-1.5 whitespace-nowrap"><span className={`px-2 py-0.5 rounded-full font-semibold ${isAlert ? "bg-mb-danger-light text-mb-danger-text" : "bg-mb-success-light text-mb-success-text"}`}>{m.flags}</span></td>
                                         <td className="px-2 py-1.5 whitespace-nowrap" style={{ color: C.muted }}>{m.lastUpdated}</td>
-                                        {m.vals.map((v, j) => (<td key={j} className="px-2 py-1.5 text-right" style={{ color: v ? C.ink : "#CBD5E1", background: monthInSelection(sel, j) ? "rgba(161,209,213,0.22)" : "transparent", fontWeight: monthInSelection(sel, j) ? 700 : 400 }}>{v ? fmt1(v) : "·"}</td>))}
+                                        {m.vals.map((v, j) => (<td key={j} className="px-2 py-1.5 text-right" style={{ color: v ? C.ink : C.muted, background: monthInSelection(sel, j) ? "var(--row-hover)" : "transparent", fontWeight: monthInSelection(sel, j) ? 700 : 400 }}>{v ? fmt1(v) : "·"}</td>))}
                                     </tr>
                                 );
                             })}
@@ -808,24 +823,24 @@ function ExceptionsView({ data, year, sel, period }: { data: WaterData; year: st
         <div className="space-y-5">
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                 <Kpi icon={ClipboardList} label="Open Exceptions" value={rows.length} bg="var(--chart-bg-purple)" ic="#4D445D" sub="Auto-generated from selected period" />
-                <Kpi icon={XCircle} label="Critical" value={critical} bg="var(--chart-bg-red)" ic="#B85C5C" sub="Immediate validation/action" />
+                <Kpi icon={XCircle} label="Critical" value={critical} bg="var(--chart-bg-red)" ic="var(--mb-danger-text)" sub="Immediate validation/action" />
                 <Kpi icon={AlertTriangle} label="Watch" value={watch} bg="var(--chart-bg-orange)" ic="#B5703A" sub="Monitor or verify" />
             </div>
             <Panel title="Exceptions & Actions Register" icon={ClipboardList} note="Operational action queue: high-loss zones/buildings, zero readings, sudden spikes, negative values, missing readings and reconciliation mismatches.">
                 <div className="flex justify-end mb-2">
-                    <button onClick={() => downloadRows(rows, `water-exceptions-actions-${year}.csv`)} className="flex items-center gap-1.5 px-3 py-2 text-sm font-semibold" style={{ background: C.primary, color: "#fff", borderRadius: RADIUS.md }}><Download className="w-4 h-4" />Export Actions</button>
+                    <button onClick={() => downloadRows(rows, `water-exceptions-actions-${year}.csv`)} className="flex items-center gap-1.5 px-3 py-2 text-sm font-semibold" style={{ background: C.primary, color: "var(--primary-foreground)", borderRadius: RADIUS.md }}><Download className="w-4 h-4" />Export Actions</button>
                 </div>
                 <div className="overflow-auto" style={{ maxHeight: 560 }}>
                     <table className="w-full text-[12px]">
-                        <thead className="sticky top-0 z-10" style={{ background: C.primary, color: "#fff" }}>
+                        <thead className="sticky top-0 z-10" style={{ background: C.primary, color: "var(--primary-foreground)" }}>
                             <tr><th className="text-left px-3 py-2">Category</th><th className="text-left px-2 py-2">Item</th><th className="text-left px-2 py-2">Severity</th><th className="text-right px-2 py-2">Value</th><th className="text-left px-2 py-2">Owner</th><th className="text-left px-2 py-2">Status</th><th className="text-left px-3 py-2">Remarks / Suggested Action</th></tr>
                         </thead>
                         <tbody>
-                            {rows.map((r, i) => { const st = r.Severity === "Critical" ? { c: "#B85C5C", bg: "#F7E4E4" } : r.Severity === "Watch" ? { c: "#9A7B1F", bg: "#FBF3DD" } : { c: "#5E8C77", bg: "#EAF3EE" }; return (
+                            {rows.map((r, i) => { const stClass = r.Severity === "Critical" ? "bg-mb-danger-light text-mb-danger-text" : r.Severity === "Watch" ? "bg-mb-warning-light text-mb-warning-text" : "bg-mb-success-light text-mb-success-text"; return (
                                 <tr key={i} style={{ background: i % 2 ? "var(--wm-zebra)" : "var(--wm-card)" }}>
                                     <td className="px-3 py-1.5 font-semibold" style={{ color: C.ink }}>{r.Category}</td>
                                     <td className="px-2 py-1.5" style={{ color: C.ink }}>{r.Item}</td>
-                                    <td className="px-2 py-1.5"><span className="px-2 py-0.5 rounded-full text-[11px] font-bold" style={{ background: st.bg, color: st.c }}>{r.Severity}</span></td>
+                                    <td className="px-2 py-1.5"><span className={`px-2 py-0.5 rounded-full text-[11px] font-bold ${stClass}`}>{r.Severity}</span></td>
                                     <td className="px-2 py-1.5 text-right font-mono" style={{ color: C.ink }}>{r.Value}</td>
                                     <td className="px-2 py-1.5" style={{ color: C.muted }}>{r.Owner}</td>
                                     <td className="px-2 py-1.5"><span className="px-2 py-0.5 rounded-full text-[11px] font-semibold" style={{ background: "var(--wm-comp)", color: C.heading }}>{r.Status}</span></td>
@@ -957,7 +972,7 @@ export function WaterMonthlyDashboard({ waterMeters }: { waterMeters: WaterMeter
             </p>
 
             {anomaly && (
-                <div className="flex items-center gap-2 text-xs font-medium px-3 py-2 rounded-lg" style={{ background: "#FDECEC", color: "#B23B3B", border: "1px solid #F5C2C2" }}>
+                <div className="flex items-center gap-2 text-xs font-medium px-3 py-2 rounded-lg border bg-mb-danger-light text-mb-danger-text border-mb-danger">
                     <AlertTriangle className="w-4 h-4 shrink-0" /> {MONTHS[safeStart]} {year} contains source billing adjustments (estimate/reset), so this month&apos;s balance isn&apos;t reliable — use Year-to-date for an accurate figure.
                 </div>
             )}

--- a/muscatbay/app/components/water/water-database-table.tsx
+++ b/muscatbay/app/components/water/water-database-table.tsx
@@ -56,6 +56,15 @@ const LEVEL_STYLES: Record<string, string> = {
     'DC': 'bg-badge-amber/20 text-badge-amber-fg ring-1 ring-badge-amber/45 dark:bg-badge-amber/15 dark:ring-badge-amber/35',
 };
 
+// Type badge colors — sourced from --badge-* tokens in globals.css.
+// 'Supply' gets the blue treatment; every other type falls back to the
+// secondary/primary pairing (see DEFAULT_TYPE_BADGE_STYLE).
+const DEFAULT_TYPE_BADGE_STYLE =
+    'bg-secondary text-primary-foreground ring-1 ring-secondary/60 dark:bg-secondary/90 dark:text-primary-foreground dark:ring-secondary/50';
+const TYPE_BADGE_STYLES: Record<string, string> = {
+    'Supply': 'bg-badge-blue/12 text-badge-blue-fg ring-1 ring-badge-blue/30 dark:bg-badge-blue/20 dark:ring-badge-blue/30',
+};
+
 // All unique levels
 const ALL_LEVELS = ['L1', 'L2', 'L3', 'L4', 'DC'];
 
@@ -137,7 +146,7 @@ function ColumnVisibilityDropdown({
                                 type="button"
                                 onClick={showAll}
                                 aria-label={`Show all ${months.length} months`}
-                                className="text-sm px-2 py-1 rounded bg-muted dark:bg-muted hover:bg-border dark:hover:bg-border"
+                                className="text-sm px-2 py-1 rounded bg-muted dark:bg-muted hover:bg-border dark:hover:bg-border pointer-coarse:inline-flex pointer-coarse:items-center pointer-coarse:justify-center pointer-coarse:min-h-11 pointer-coarse:min-w-11 pointer-coarse:px-3"
                             >
                                 All ({months.length})
                             </button>
@@ -145,7 +154,7 @@ function ColumnVisibilityDropdown({
                                 type="button"
                                 onClick={showLast12}
                                 aria-label="Show last 12 months"
-                                className="text-sm px-2 py-1 rounded bg-muted dark:bg-muted hover:bg-border dark:hover:bg-border"
+                                className="text-sm px-2 py-1 rounded bg-muted dark:bg-muted hover:bg-border dark:hover:bg-border pointer-coarse:inline-flex pointer-coarse:items-center pointer-coarse:justify-center pointer-coarse:min-h-11 pointer-coarse:min-w-11 pointer-coarse:px-3"
                             >
                                 Last 12
                             </button>
@@ -153,7 +162,7 @@ function ColumnVisibilityDropdown({
                                 type="button"
                                 onClick={showLast6}
                                 aria-label="Show last 6 months"
-                                className="text-sm px-2 py-1 rounded bg-muted dark:bg-muted hover:bg-border dark:hover:bg-border"
+                                className="text-sm px-2 py-1 rounded bg-muted dark:bg-muted hover:bg-border dark:hover:bg-border pointer-coarse:inline-flex pointer-coarse:items-center pointer-coarse:justify-center pointer-coarse:min-h-11 pointer-coarse:min-w-11 pointer-coarse:px-3"
                             >
                                 Last 6
                             </button>
@@ -390,15 +399,16 @@ export function WaterDatabaseTable({ meters, months }: WaterDatabaseTableProps) 
     const renderRow = (meter: WaterMeter, rowIndex: number) => {
         const zoneBorder = ZONE_BORDER_VAR[meter.zone] || ZONE_BORDER_VAR['N/A'];
         const levelStyle = LEVEL_STYLES[meter.level] || 'bg-muted text-foreground';
+        const typeStyle = TYPE_BADGE_STYLES[meter.type] || DEFAULT_TYPE_BADGE_STYLE;
 
         return (
             <tr
                 key={meter.accountNumber}
-                style={{ borderLeftColor: zoneBorder }}
+                style={{ '--zone-border': zoneBorder } as React.CSSProperties}
                 className={cn(
                     "border-b border-border/80 dark:border-border/80 hover:bg-secondary/5 dark:hover:bg-muted/40 transition-colors",
                     rowIndex % 2 === 1 && "bg-muted/40 dark:bg-muted/20",
-                    "border-l-2"
+                    "border-l-2 border-l-[color:var(--zone-border)]"
                 )}
             >
                 <td className="py-4 px-5 font-medium whitespace-nowrap col-sticky w-[120px] sm:w-[180px] md:w-[200px]">
@@ -423,9 +433,7 @@ export function WaterDatabaseTable({ meters, months }: WaterDatabaseTableProps) 
                 <td className="py-4 px-5">
                     <span className={cn(
                         "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap",
-                        meter.type === 'Supply'
-                            ? 'bg-badge-blue/12 text-badge-blue-fg ring-1 ring-badge-blue/30 dark:bg-badge-blue/20 dark:ring-badge-blue/30'
-                            : 'bg-secondary text-primary-foreground ring-1 ring-secondary/60 dark:bg-secondary/90 dark:text-primary-foreground dark:ring-secondary/50'
+                        typeStyle
                     )}>
                         {meter.type}
                     </span>

--- a/muscatbay/app/public/sw.js
+++ b/muscatbay/app/public/sw.js
@@ -1,10 +1,11 @@
 // Bump this version to force every client to flush stale caches on their
 // next visit. The `activate` handler below deletes any cache whose name
 // doesn't match CACHE_NAME, so bumping invalidates everything older.
-// Last bumped 2026-04-13: unstick users stranded on caches containing the
-// pre-51188c5 bundle whose HMR/proxy flood tripped Supabase's auth rate
-// limiter and showed "this page couldn't load" in the browser shell.
-const CACHE_NAME = "muscatbay-v4";
+// Last bumped 2026-06-27: unstick clients stranded on a cached app shell that
+// referenced deleted `_next/` chunk hashes — those 404'd, the bundle never
+// loaded, and the app hung on the splash screen. (The SW is also no longer
+// registered in local development; see components/pwa/register-sw.tsx.)
+const CACHE_NAME = "muscatbay-v5";
 const STATIC_ASSETS = [
   "/",
   "/manifest.json",


### PR DESCRIPTION
## Summary

Implements all `/audit` recommended actions from the application-wide technical quality audit (which scored **16/20 — Good**). Work was orchestrated across **14 files via file-partitioned parallel agents** (each agent owned a disjoint file set so concurrent edits never collided), then verified centrally.

**Verification:** `npm run lint` ✓ · `npx tsc --noEmit` ✓ · `npm run build` ✓ (23/23 routes compile).

## Changes by severity

### P0 — Accessibility (`/harden`)
- **CSVUploadDialog**: the drag-and-drop zone was a clickable `<div>` with no keyboard path. Now keyboard-operable — `role="button"`, `tabIndex`, `aria-label`, and an Enter/Space `onKeyDown` handler (gated to interactive states). Fixes **WCAG 2.1.1 (Keyboard, Level A)**.

### P1 — Theming / dark-mode correctness (`/normalize`, `/harden`)
- **water-monthly-dashboard**: migrated ~40 raw hex status colors used on DOM elements to dark-mode-aware `mb-*` token classes / CSS vars (`bg-mb-danger-light`, `text-mb-success-text`, etc.); table headers now use `var(--primary-foreground)`; month-selection highlight uses `var(--row-hover)`. Recharts SVG `stroke`/`fill` props intentionally left as hex (CSS custom properties don't resolve in SVG presentation attributes).
- **daily-report** (`inline-zone-l3-table`, `zone-panel`): routed the local `PALETTE` hex object's DOM status colors through `mb-*` tokens + `color-mix()` tints.
- **globals.css**: added `.dark` overrides for the eight `--chart-bg-*` tokens (deep low-chroma tints) so KPI tile backgrounds read correctly in dark mode.
- **date-range-picker**: fixed inactive-track contrast on dark surfaces (`bg-muted` was near-indistinguishable from the card).

### P1 — Forms (`/clarify`)
- **settings**: explicit `aria-label="Upload avatar"` on the avatar file input.

### P2 — Touch targets (WCAG 2.5.5) & performance (`/adapt`, `/optimize`)
- **table-toolbar**, **multi-select-dropdown**, **water-database-table**: bumped sub-44px controls to 44px on touch via `pointer-coarse:min-h-11` (desktop look unchanged).
- **water-monthly-dashboard**: `transition-all` → `transition-shadow`; hoisted Recharts tooltip formatters to identity-stable module-level functions; `useCallback` for zone-card `onClick`.
- **water-database-table**: per-row inline `borderLeftColor` → CSS variable; type-badge class chain → module-level lookup map.

### P3 — Polish (`/polish`)
- **hvac**: fixed `h1 → h3` heading skip (now `h2`).
- **bottom-nav**: label `text-[10px]` → `text-[11px]` for small-font legibility.
- **circular-gauge**: `role="img"` + descriptive `aria-label`; decorative circles `aria-hidden`.
- **splash-screen**: documented the intentional always-dark `text-white`.

## Notes
- Recharts is already dynamically imported (`next/dynamic`, `ssr:false`) and the build confirms code-splitting; no change needed there.
- No `any` types introduced; all new helpers are explicitly typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6QnSJRwQzuASqSHyRTin3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved water dashboards and tables with clearer theme-aware colors and stronger contrast in dark mode.
  * Updated chart, gauge, and report visuals for better readability across light and dark themes.

* **Bug Fixes**
  * Fixed service worker caching so updated content loads more reliably after refresh.
  * Prevented development builds from reusing stale service worker/cache data.

* **Accessibility**
  * Added keyboard support and screen-reader labels to upload and chart controls.
  * Improved touch target sizes and navigation label sizing for easier use on mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->