### PR TITLE
Reorganize Assets Register layout: KPI cards up top, search above table

### DIFF
--- a/muscatbay/app/app/assets/page.tsx
+++ b/muscatbay/app/app/assets/page.tsx
@@ -388,7 +388,10 @@ export default function AssetsPage() {
             <TabNavigation tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />
 
             <div className="space-y-4">
-                {/* Toolbar */}
+                {/* KPI cards — moved above the toolbar so they sit at the top of the section */}
+                {activeTab === 'overview' && <StatsGrid stats={stats} />}
+
+                {/* Toolbar — search filter now sits directly above the table */}
                 <TableToolbar>
                     <div className="relative flex-1 min-w-0 sm:min-w-[200px] max-w-md">
                         <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
@@ -426,7 +429,6 @@ export default function AssetsPage() {
                 {/* ── TAB: OVERVIEW ─────────────────────────────────────────────────────── */}
                 {activeTab === 'overview' && (
                     <div id="panel-overview" role="tabpanel" aria-labelledby="tab-overview" tabIndex={0} className="space-y-4">
-                    <StatsGrid stats={stats} />
                     <div className="ops-table-shell">
                         {/* Mobile cards */}
                         <div className="md:hidden divide-y divide-border dark:divide-border">


### PR DESCRIPTION
## Summary

Reorganizes the layout of the **Assets Register** section (`muscatbay/app/app/assets/page.tsx`) per request:

- **KPI cards repositioned upwards** — the `StatsGrid` (KPI cards) was previously rendered *inside* the Overview tab panel, below the search/filter toolbar. It now sits at the top of the section, above the toolbar.
- **Search filter moved directly above the table** — with the KPI cards moved up, the search filter / toolbar now sits directly above the table instead of between the KPI cards and the table.

### Before (Overview tab)
1. Search filter / toolbar
2. Active filter pills
3. KPI cards
4. Table

### After (Overview tab)
1. **KPI cards**
2. **Search filter / toolbar**
3. Active filter pills
4. Table

## Changes
- Moved `<StatsGrid stats={stats} />` (guarded by `activeTab === 'overview'`) to the top of the section container, above `<TableToolbar>`.
- Removed the original `StatsGrid` render from inside the Overview tab panel.

KPI cards remain Overview-only (unchanged behavior); they are simply repositioned. No data-layer, filtering, sorting, or pagination logic was touched.

## Verification
- `npx eslint app/assets/page.tsx` — passes (exit 0)
- `npx tsc --noEmit` — no type errors in `app/assets/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vkr83MKnCpsKpznR7SAg5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkr83MKnCpsKpznR7SAg5f)_