### PR TITLE
Water Monthly: clock-proof the fetch window, flush stale client caches

### DIFF
--- a/muscatbay/app/functions/api/water.ts
+++ b/muscatbay/app/functions/api/water.ts
@@ -20,19 +20,16 @@ import {
 import type { WaterMeter } from '@/lib/water-data';
 
 // Earliest period in the seeded dataset. Acts as a floor so old backfills
-// can't accidentally inflate the response. The ceiling is derived from the
-// current month so accidental future-dated rows can't leak through.
+// can't accidentally inflate the response. There is deliberately NO ceiling:
+// deriving one from the device clock hid legitimate months from users whose
+// tablet date was set in the past (the dashboard capped at the device's
+// month), and the write path now guards against garbage periods anyway.
 const PERIOD_FLOOR = '2024-01';
 
 // Supabase / PostgREST caps every response at 1000 rows regardless of the
 // `range()` value the client passes, so we page through `consumption` rows
 // in fixed-size windows until a short page signals the end.
 const CONSUMPTION_PAGE_SIZE = 1000;
-
-function currentPeriod(): string {
-    const now = new Date();
-    return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
-}
 
 // Mirror the legacy-name translations baked into the "Water System" SQL view
 // so downstream code (lib/water-data.ts, water-database-table, etc.) keeps
@@ -126,14 +123,12 @@ export async function getWaterMetersFromSupabase(): Promise<WaterMeter[]> {
             return [];
         }
 
-        const periodCeiling = currentPeriod();
         const consumptionRows: MonthlyConsumptionRow[] = [];
         for (let from = 0; ; from += CONSUMPTION_PAGE_SIZE) {
             const { data, error } = await client
                 .from('water_monthly_consumption')
                 .select('account_number, period, consumption')
                 .gte('period', PERIOD_FLOOR)
-                .lte('period', periodCeiling)
                 .order('account_number')
                 .order('period')
                 .range(from, from + CONSUMPTION_PAGE_SIZE - 1)

--- a/muscatbay/app/public/sw.js
+++ b/muscatbay/app/public/sw.js
@@ -1,11 +1,16 @@
 // Bump this version to force every client to flush stale caches on their
 // next visit. The `activate` handler below deletes any cache whose name
 // doesn't match CACHE_NAME, so bumping invalidates everything older.
-// Last bumped 2026-06-27: unstick clients stranded on a cached app shell that
-// referenced deleted `_next/` chunk hashes — those 404'd, the bundle never
-// loaded, and the app hung on the splash screen. (The SW is also no longer
-// registered in local development; see components/pwa/register-sw.tsx.)
-const CACHE_NAME = "muscatbay-v5";
+// Last bumped 2026-07-03: flush clients still showing the pre-June water
+// data / pre-auto-sync build. The new SW takes control immediately
+// (skipWaiting + clients.claim) and register-sw.tsx reloads previously
+// controlled tabs on controllerchange, so stale sessions self-heal on
+// their next visit.
+// Previous bump 2026-06-27: unstick clients stranded on a cached app shell
+// that referenced deleted `_next/` chunk hashes — those 404'd, the bundle
+// never loaded, and the app hung on the splash screen. (The SW is also no
+// longer registered in local development; see components/pwa/register-sw.tsx.)
+const CACHE_NAME = "muscatbay-v6";
 const STATIC_ASSETS = [
   "/",
   "/manifest.json",


### PR DESCRIPTION
# Why

Follow-up to #29. A user still reported the Monthly range picker capped at May-26 with June missing from the dropdown — on a production deployment and dataset that verifiably serve June. Two client-side staleness paths reproduce that symptom; both are closed here.

# What changed

- **`functions/api/water.ts` — remove the device-clock period ceiling.** The fetch previously excluded any period after the *device's* current month (`currentPeriod()` from `new Date()`). A tablet whose date is set before June reproduces the report exactly: `2026-06` is filtered out, the slider clamps at May-26, and June never appears in the dropdown — on any build. The `2024-01` floor stays; there is no ceiling anymore, so every month present in `water_monthly_consumption` always reaches the dashboard regardless of the device clock. (Stray future-dated rows are now guarded at the write path by the #29 view trigger.)
- **`public/sw.js` — bump `CACHE_NAME` v5 → v6.** Clients still holding a pre-June session get their caches purged on the next visit, and `register-sw.tsx`'s `controllerchange` handler auto-reloads previously controlled tabs — stale sessions self-heal into the current build and fresh data without user action. This is the repo's documented mechanism for exactly this situation.

# Verification

- 108/108 tests, `lint`, `tsc --noEmit`, `next build` all pass.
- Chromium E2E against the real production dataset: Monthly renders **Jan–Jun 2026**, "June 2026" selectable in the range picker, June column in the Main Database tab — 5/5 checks, no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGsGjWXEihwGPaeKmrde3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGsGjWXEihwGPaeKmrde3a)_