### PR TITLE
Add living PROJECT_STATUS.md + auto-updating development log

### DIFF
--- a/.github/workflows/project-status-log.yml
+++ b/.github/workflows/project-status-log.yml
@@ -1,0 +1,110 @@
+# Appends every change pushed to main into the "Development log" section of
+# PROJECT_STATUS.md, so the project's living status file documents every
+# merged task with zero human action.
+#
+# Loop safety (three layers):
+#   1. Pushes made with the default GITHUB_TOKEN do not trigger workflows.
+#   2. The job skips entirely when the pusher is github-actions[bot].
+#   3. The bot's own commit subjects start with "docs(status):" and are
+#      filtered out of the log, and already-present lines are deduped.
+#
+# Note: the bot's docs-only commit still triggers a Vercel production build
+# of an unchanged app — harmless, and users are unaffected.
+
+name: Project status log
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: project-status-log
+  cancel-in-progress: false
+
+jobs:
+  append:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    env:
+      BEFORE: ${{ github.event.before }}
+      AFTER: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Append pushed changes to PROJECT_STATUS.md
+        run: |
+          set -euo pipefail
+          FILE="PROJECT_STATUS.md"
+          MARK='<!-- STATUS:LOG:BEGIN -->'
+
+          if [ ! -f "$FILE" ]; then
+            echo "$FILE missing — nothing to update."
+            exit 0
+          fi
+          if ! grep -qF "$MARK" "$FILE"; then
+            echo "Log marker not found in $FILE — skipping."
+            exit 0
+          fi
+
+          # Push range; fall back to the head commit alone on first/force push.
+          if [[ "$BEFORE" =~ ^0+$ ]] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
+            RANGE=(-1 "$AFTER")
+          else
+            RANGE=("$BEFORE..$AFTER")
+          fi
+
+          NEW="$(mktemp)"
+          # First-parent only: a squash/merge to main logs as one entry, not
+          # one per branch commit. %cs = date the change landed on main.
+          git log --first-parent --format='%cs|%s' "${RANGE[@]}" |
+          while IFS='|' read -r day subject; do
+            case "$subject" in
+              "docs(status):"*) continue ;;
+            esac
+            line="- ${day} — ${subject}"
+            # "--" ends option parsing: log lines start with "-" and would
+            # otherwise be read by grep as options.
+            if ! grep -qxF -- "$line" "$FILE"; then
+              printf '%s\n' "$line" >> "$NEW"
+            fi
+          done
+
+          if [ ! -s "$NEW" ]; then
+            echo "No new entries to log."
+            exit 0
+          fi
+
+          awk -v marker="$MARK" -v newfile="$NEW" '
+            { print }
+            $0 == marker {
+              while ((getline l < newfile) > 0) print l
+              close(newfile)
+            }
+          ' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+
+          if git diff --quiet -- "$FILE"; then
+            echo "Log unchanged."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$FILE"
+          git commit -m "docs(status): log $(git rev-parse --short "$AFTER") in development log [skip ci]"
+
+          # Retry around racing pushes; the concurrency group already
+          # serializes runs of this workflow itself.
+          for attempt in 1 2 3; do
+            if git push origin main; then
+              exit 0
+            fi
+            git pull --rebase origin main
+          done
+          echo "Failed to push status log update after 3 attempts."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,18 @@
 # Muscat Bay Utility Management App
 
+## Living Project Status — read this first
+
+- **[`PROJECT_STATUS.md`](./PROJECT_STATUS.md) (repo root) is the single source of
+  truth for the app's current state**: module status, data pipelines, in-flight
+  work, known gaps and a full development log. Read it BEFORE exploring the
+  codebase to understand what exists and where things stand.
+- **After completing any task** that changes features, schema, data pipelines,
+  module status or known gaps, **update the relevant curated section of
+  `PROJECT_STATUS.md` in the same commit/PR** as the change.
+- The "Development log" section of that file is appended automatically on every
+  push to `main` (`.github/workflows/project-status-log.yml`) — never hand-edit
+  log entries; curate meaning in the sections above it.
+
 ## Quick Reference
 
 | Item | Value |

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,133 @@
+# Muscat Bay — Project Status
+
+> **This is the living, single source of truth for the application's current state.**
+> An AI session (or a new developer) should read this file FIRST — before exploring
+> the codebase — to understand what exists, what state it is in, how data flows,
+> and what is in flight.
+>
+> **How this file stays current**
+> - The **Development log** section is appended **automatically** by
+>   `.github/workflows/project-status-log.yml` on every push to `main` — every
+>   merged change lands there with no human action.
+> - The **curated sections** (everything else) are updated by whoever completes a
+>   task that changes them: AI sessions are instructed via `CLAUDE.md` to update
+>   the relevant section in the same PR as the change itself.
+> - Deep reference detail lives in the linked docs at the bottom — this file
+>   holds the *current state*, not the full manuals.
+
+**Last curated review:** 2026-07-03
+
+---
+
+## 1. The application at a glance
+
+Utility & facility operations dashboard for **Muscat Bay** (Oman): water,
+electricity, STP plant, assets, contractors, HVAC, pest control and fire safety
+in one Next.js app backed by Supabase.
+
+| Item | Value |
+|---|---|
+| Production | **https://muscatbay.work** (aliases: www.muscatbay.work, muscatbay.vercel.app) |
+| Deploys | Vercel project `muscatbay`, auto-deploy on push to `main` (root: `muscatbay/app`) |
+| Repo | `ARahim900/muscatbay`, default branch `main` |
+| Backend | Supabase project `utnlgeuqajmwibqmdmgt` (ap-northeast-1) — Postgres 17, Auth, Realtime |
+| Stack | Next.js 16 · React 19 · TypeScript 5 · Tailwind 4 · Recharts 3 · shadcn/ui · PWA (service worker `public/sw.js`, cache `muscatbay-v6`) |
+| Auth | Supabase email/password; client-side route protection (`components/auth/auth-provider.tsx`); RBAC role column (2026-05-13 migration) |
+| Tests / checks | Vitest (108 tests), ESLint, `tsc --noEmit`, `next build` — all green as of 2026-07-03 |
+
+Users are operations staff on control-room tablets (dark mode primary) and
+executives (dashboard KPIs). Live data — there is no demo mode.
+
+## 2. Module status
+
+| Module | Route | State | Data source | Notes |
+|---|---|---|---|---|
+| Dashboard (command deck) | `/` | ✅ Live | aggregated from module tables | KPI deck, live ops strip, module status rail |
+| Water — Monthly | `/water` (Monthly tab) | ✅ Live, fully dynamic | `water_meters` + `water_monthly_consumption` | Balance A1/A2/A3, zones, buildings, DC, exceptions; months appear automatically (see §3) |
+| Water — Daily | `/water` (Daily tab) | ✅ Live | `water_daily_consumption`, `water_loss_daily/summary` | Daily briefing, zone ledgers; fed by CSV upload / Grafana sync |
+| Electricity | `/electricity` | ✅ Live | `electricity_meters` / `electricity_readings` | Monthly readings through Mar-26 loads (see sql/migrations) |
+| STP Plant | `/stp` | ✅ Live | `stp_operations` | Daily ops through May-26 loads; 3D plant twin exists only on unmerged PR #21 |
+| Assets | `/assets` | ✅ Live | `master_assets_register` | 6-card KPI grid; register table with toolbar (PR #25) |
+| Contractors | `/contractors` | ✅ Live | `Contractor_Tracker`, contracts tables | AMC tracking, yearly costs |
+| HVAC | `/hvac` | ✅ Live | Gulf Expert tables | Findings/maintenance model — the layout template other modules align to |
+| Fire Safety | `/firefighting` | ✅ Live (redesigned 2026-06-30) | `fire_safety_equipment`, `fire_ppm_activities`, `fire_issues_register`, `fire_ppm_contacts` | BEC AMC: 3 PPM cycles × 4 zones; aligned with HVAC layout (PRs #26/#27) |
+| Pest Control | `/pest-control` | ✅ Live | pest tables | |
+| Firefighting quotes, settings, auth pages | various | ✅ Live | | |
+
+## 3. Water monthly data — how it works now (important)
+
+Rebuilt 2026-07-03 (PRs #29/#30) so that **any monthly value present in the
+backend appears in the frontend automatically** — the recurring "dashboard
+stops at last month" problem is structurally closed:
+
+- The app reads long-format tables: `water_meters` (registry, 350 meters,
+  `meter_id` like `MB-L2-001`) + `water_monthly_consumption`
+  (`meter_id, period 'YYYY-MM', consumption`). No month list is hardcoded
+  anywhere in the app; no fetch ceiling (device-clock independent).
+- The legacy wide sheet **"Water System" is a writable VIEW**: INSERT/UPDATE
+  against it (Supabase Studio edits, old Airtable sync scripts,
+  `scripts/update-water-data.ts`) fire an INSTEAD OF trigger
+  (`water_system_view_write`) that upserts the base tables — auto-registering
+  brand-new meters and translating legacy zone/type spellings to clean codes.
+- The view **rebuilds itself monthly** (pg_cron job `water-system-view-rebuild`,
+  00:10 UTC on the 1st) via `rebuild_water_system_view()`, extending its month
+  columns one year past the newest data — new years need no schema work.
+- `water_meters` + `water_monthly_consumption` are in the `supabase_realtime`
+  publication; the Water page and dashboard hook subscribe to them, so open
+  dashboards refresh live when data lands.
+- Migration source of truth: `muscatbay/app/sql/migrations/20260703_water_monthly_auto_sync.sql`
+  (applied to the live DB as `water_monthly_auto_sync` + `_hardening`).
+- Daily data path (unchanged): CSV/Grafana → `water_daily_consumption`
+  (GitHub-Actions Grafana sync exists on unmerged PR #6 only).
+
+## 4. Known gaps & data debt
+
+- **June 2026 NAMA main-bulk reading missing** (`C43659`, period `2026-06`) —
+  supply shows 0 m³ for June until the bill value is entered; it will appear
+  automatically once entered (any surface: view `jun_26` column or base table).
+- `Water_System` (underscore) table is an abandoned pre-v2 orphan (columns end
+  Feb-26) — not read by anything; candidate for cleanup.
+- Supabase security advisors carry pre-existing findings on other tables
+  (e.g. RLS disabled on some legacy tables) — water auto-sync objects are clean.
+- Monthly loads for electricity/STP still arrive via hand-run SQL in
+  `sql/migrations/` — same class of manual step water had before 2026-07-03.
+
+## 5. In-flight work (open PRs)
+
+- **#28 Senior-management water dashboard** — new default "Management" tab on
+  `/water` (YTD KPIs + latest daily snapshot). Active, awaiting review/merge.
+- **#21 3D app logo + STP plant twin** — draft; new logo assets + Three.js twin.
+- **#6 Grafana → Supabase daily water sync workflow** — draft; needs 7 repo
+  secrets before merge (see PR body).
+- **#5 / #4** — stale (May-26 daily backfill already applied differently; codex
+  lint fixes) — review for close-or-rebase.
+
+## 6. Development log (auto-updated — newest first)
+
+Entries below the marker are appended automatically on every push to `main`.
+Do not hand-edit existing entries; curate meaning in the sections above.
+
+<!-- STATUS:LOG:BEGIN -->
+- 2026-07-03 — Water Monthly: clock-proof the fetch window, flush stale client caches (#30)
+- 2026-07-03 — Water Monthly: auto-sync any backend data to the dashboard, live (#29)
+- 2026-06-30 — Align Fire Safety section with HVAC: 3 subsections, unified styling (#27)
+- 2026-06-30 — Fire Safety: rename PPM Tracker to Maintenance, align with HVAC layout (#26)
+- 2026-06-30 — Redesign Fire Safety Management around BEC PPM cycles, zones & live data
+- 2026-06-30 — Remove DISCIPLINES KPI card from Assets Register (7 → 6 cards)
+- 2026-06-30 — Reorganize Assets Register layout: KPI cards up top, search above table (#25)
+- 2026-06-27 — feat(ui): unify KPI cards, tables & daily water section app-wide to the monthly standard
+- 2026-06-27 — revert(water): restore monthly dashboard to original
+- 2026-06-27 — fix(ui,water): review fixes — selected-row hover, STP axis precision, date-picker gaps & cross-year sync
+- 2026-06-27 — Fix audit findings + stuck-splash service-worker bug (#24)
+- 2026-06-26 — feat(water): rebuild Monthly section with Supabase-wired loss dashboard (#23)
+<!-- STATUS:LOG:END -->
+
+## 7. Where the deep detail lives
+
+| Doc | Content | Freshness |
+|---|---|---|
+| `CLAUDE.md` (root) | Build/run commands, conventions, structure — auto-loaded by AI sessions | maintained |
+| `BRAND_DESIGN.md` / `PRODUCT.md` / `muscatbay/app/DESIGN_SYSTEM.md` | Brand, tokens, design principles (BRAND_DESIGN wins conflicts) | stable |
+| `muscatbay/app/ARCHITECTURE.md`, `FOLDER_STRUCTURE.md`, `README.md` | Architecture & layout snapshots | 2026-05 snapshot |
+| `muscatbay/app/DATABASE_AUDIT.md`, `AUTHENTICATION_AUDIT_REPORT.md` | Point-in-time audits | 2026-06 / earlier |
+| `muscatbay/app/sql/migrations/` | Schema & data-load history (files are the DB change log) | append-only |


### PR DESCRIPTION
# Why

One central, always-current file that consolidates the application's design state and development progress — so an AI session (or a new developer) can understand the app's features, stage, and context from a single read instead of re-analysing the whole repository each time. The repo had good docs (`CLAUDE.md`, design specs, audits) but they are conventions or point-in-time snapshots; nothing tracked *current state* and nothing kept anything up to date automatically.

# What changed

- **`PROJECT_STATUS.md` (repo root)** — the living source of truth, seeded today with a verified snapshot: app at a glance (production URL, deploy pipeline, Supabase project), per-module status table, the water monthly data architecture (post #29/#30 auto-sync machinery), known gaps & data debt (e.g. the missing June NAMA reading), in-flight PRs, a development log, and a map of the deep-reference docs.
- **`.github/workflows/project-status-log.yml`** — on every push to `main`, appends one dated entry per landed change into the file's marker-delimited log (first-parent, so a squashed PR logs once). Dedupes, filters its own bot commits, survives force-pushes, and is loop-safe three ways (GITHUB_TOKEN pushes don't retrigger workflows; actor guard; `docs(status):` subject filter). Every merged task is therefore documented with zero human action.
- **`CLAUDE.md`** — new leading section: AI sessions must read `PROJECT_STATUS.md` first for current state and update its curated sections in the same PR as any change that alters them; the log itself is CI-maintained.

# Verification

The append logic was dry-run locally against the real file: marker insertion, duplicate suppression (including an end-of-options `grep --` fix caught by the dry run — log lines start with `-`), bot-commit filtering, and re-run idempotence all pass. The merge of this PR is the live first run: the workflow should append this PR's own entry to the log on `main` within a minute of merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGsGjWXEihwGPaeKmrde3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGsGjWXEihwGPaeKmrde3a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a central project status page with up-to-date information on app areas, data coverage, known gaps, and ongoing work.
  * Updated contributor guidance so the project status is kept in sync with feature, schema, and pipeline changes.
  * Introduced an automated status log that appends recent merged changes to the project status page on each push to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->